### PR TITLE
Generate bindings for Microsoft.UI.Xaml.Controls.NavigationView

### DIFF
--- a/Sources/WinUI/Generated/Microsoft.UI.Xaml.Controls+ABI.swift
+++ b/Sources/WinUI/Generated/Microsoft.UI.Xaml.Controls+ABI.swift
@@ -26,6 +26,30 @@ private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAppBarStatics: WindowsF
     .init(Data1: 0x0DC7172C, Data2: 0xA03D, Data3: 0x5AE4, Data4: ( 0x95,0x38,0xFF,0xD8,0x04,0x82,0x3B,0xCE ))// 0DC7172C-A03D-5AE4-9538-FFD804823BCE
 }
 
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox: WindowsFoundation.IID {
+    .init(Data1: 0x3EEA809E, Data2: 0xB2DB, Data3: 0x521D, Data4: ( 0x97,0xDB,0xE0,0x64,0x8F,0xB5,0xD7,0x98 ))// 3EEA809E-B2DB-521D-97DB-E0648FB5D798
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxQuerySubmittedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x26DA5DE4, Data2: 0x57A6, Data3: 0x57BF, Data4: ( 0xAC,0xC9,0xAA,0xC5,0x99,0xC0,0xB2,0x2B ))// 26DA5DE4-57A6-57BF-ACC9-AAC599C0B22B
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics: WindowsFoundation.IID {
+    .init(Data1: 0x9DFA2FF9, Data2: 0x1094, Data3: 0x54A8, Data4: ( 0xBE,0xEE,0xB3,0x45,0xFA,0x3E,0xE0,0x89 ))// 9DFA2FF9-1094-54A8-BEEE-B345FA3EE089
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxSuggestionChosenEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x7547C7E9, Data2: 0x7429, Data3: 0x5045, Data4: ( 0xAD,0x98,0x33,0x8A,0x96,0xB2,0x70,0xB1 ))// 7547C7E9-7429-5045-AD98-338A96B270B1
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxTextChangedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0xD7191D84, Data2: 0xE886, Data3: 0x547F, Data4: ( 0xA3,0xE2,0x12,0xF0,0xE0,0x5B,0x20,0xFA ))// D7191D84-E886-547F-A3E2-12F0E05B20FA
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxTextChangedEventArgsStatics: WindowsFoundation.IID {
+    .init(Data1: 0x40155FB9, Data2: 0x253B, Data3: 0x5624, Data4: ( 0xA1,0x7A,0x29,0x4B,0xE7,0xA0,0x7F,0x87 ))// 40155FB9-253B-5624-A17A-294BE7A07F87
+}
+
 private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIBitmapIcon: WindowsFoundation.IID {
     .init(Data1: 0xC370BC29, Data2: 0x805B, Data3: 0x5BAD, Data4: ( 0xB6,0x15,0xEC,0x64,0x0E,0x57,0x9D,0xBB ))// C370BC29-805B-5BAD-B615-EC640E579DBB
 }
@@ -438,6 +462,30 @@ private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIImageStatics: WindowsFo
     .init(Data1: 0xCB5378A8, Data2: 0x996B, Data3: 0x547E, Data4: ( 0x9C,0x4C,0x7B,0xBF,0xD9,0xDB,0xE7,0xDC ))// CB5378A8-996B-547E-9C4C-7BBFD9DBE7DC
 }
 
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadge: WindowsFoundation.IID {
+    .init(Data1: 0x82104D7F, Data2: 0x03D4, Data3: 0x5EA4, Data4: ( 0x87,0x2E,0xF9,0xEC,0xAB,0x75,0x86,0x01 ))// 82104D7F-03D4-5EA4-872E-F9ECAB758601
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeFactory: WindowsFoundation.IID {
+    .init(Data1: 0xFB498205, Data2: 0x2DE0, Data3: 0x5986, Data4: ( 0x8A,0xEC,0x2C,0x46,0xAC,0x23,0x50,0x87 ))// FB498205-2DE0-5986-8AEC-2C46AC235087
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeStatics: WindowsFoundation.IID {
+    .init(Data1: 0xB0160061, Data2: 0xB463, Data3: 0x54DE, Data4: ( 0x81,0xAC,0x64,0xF3,0x90,0xD4,0xF2,0x5D ))// B0160061-B463-54DE-81AC-64F390D4F25D
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettings: WindowsFoundation.IID {
+    .init(Data1: 0xCE810F86, Data2: 0xD4BB, Data3: 0x51BD, Data4: ( 0xBF,0x7D,0xDF,0xD1,0xE6,0xC8,0x5F,0x4A ))// CE810F86-D4BB-51BD-BF7D-DFD1E6C85F4A
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettingsFactory: WindowsFoundation.IID {
+    .init(Data1: 0x5D366775, Data2: 0x1F6E, Data3: 0x558C, Data4: ( 0xAA,0xB4,0x66,0x77,0x04,0xB3,0x07,0x0C ))// 5D366775-1F6E-558C-AAB4-667704B3070C
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettingsStatics: WindowsFoundation.IID {
+    .init(Data1: 0x10959133, Data2: 0x64CE, Data3: 0x586F, Data4: ( 0xA2,0x52,0x9E,0x26,0xFC,0x1A,0xD9,0xBA ))// 10959133-64CE-586F-A252-9E26FC1AD9BA
+}
+
 private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBar: WindowsFoundation.IID {
     .init(Data1: 0xC1C3A438, Data2: 0xDD79, Data3: 0x5D22, Data4: ( 0x9E,0x42,0x5A,0x3C,0xDF,0x81,0x13,0xA9 ))// C1C3A438-DD79-5D22-9E42-5A3CDF8113A9
 }
@@ -776,6 +824,126 @@ private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIMenuFlyoutSubItemStatic
 
 private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigate: WindowsFoundation.IID {
     .init(Data1: 0xDD06F030, Data2: 0x5D47, Data3: 0x533C, Data4: ( 0x95,0xCF,0xDE,0x25,0x6A,0x0F,0x37,0x3A ))// DD06F030-5D47-533C-95CF-DE256A0F373A
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView: WindowsFoundation.IID {
+    .init(Data1: 0xE77A4B36, Data2: 0x3DD1, Data3: 0x53D9, Data4: ( 0x9F,0x97,0x65,0xDC,0xCA,0xA7,0x4A,0x5C ))// E77A4B36-3DD1-53D9-9F97-65DCCAA74A5C
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2: WindowsFoundation.IID {
+    .init(Data1: 0x05B428CF, Data2: 0x014C, Data3: 0x56DD, Data4: ( 0x89,0x6A,0xA3,0xE7,0x08,0x9D,0x73,0xB5 ))// 05B428CF-014C-56DD-896A-A3E7089D73B5
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewBackRequestedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0xAE752207, Data2: 0xBD1B, Data3: 0x5AFA, Data4: ( 0xA8,0x72,0xE9,0xBB,0xAE,0xEA,0x0E,0xDE ))// AE752207-BD1B-5AFA-A872-E9BBAEEA0EDE
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewDisplayModeChangedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x58DCF1EA, Data2: 0x9E56, Data3: 0x522C, Data4: ( 0xB3,0xF8,0x34,0xBD,0x55,0xEC,0xAC,0xA4 ))// 58DCF1EA-9E56-522C-B3F8-34BD55ECACA4
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewFactory: WindowsFoundation.IID {
+    .init(Data1: 0xFFEA1ADA, Data2: 0x9232, Data3: 0x5507, Data4: ( 0xA3,0x20,0xED,0x2F,0xAD,0xBE,0x61,0x27 ))// FFEA1ADA-9232-5507-A320-ED2FADBE6127
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem: WindowsFoundation.IID {
+    .init(Data1: 0x3AB3D503, Data2: 0xA37C, Data3: 0x5836, Data4: ( 0x8A,0xDB,0x28,0x82,0x06,0x2E,0x73,0xA1 ))// 3AB3D503-A37C-5836-8ADB-2882062E73A1
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2: WindowsFoundation.IID {
+    .init(Data1: 0x2D5BD889, Data2: 0x9DAC, Data3: 0x5675, Data4: ( 0xB2,0x54,0x68,0x22,0x6F,0x07,0x7A,0x61 ))// 2D5BD889-9DAC-5675-B254-68226F077A61
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem3: WindowsFoundation.IID {
+    .init(Data1: 0xC6AA3120, Data2: 0xD888, Data3: 0x5C32, Data4: ( 0x8B,0xB7,0x49,0x0E,0xC9,0x1B,0x1A,0xEC ))// C6AA3120-D888-5C32-8BB7-490EC91B1AEC
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBase: WindowsFoundation.IID {
+    .init(Data1: 0x33586494, Data2: 0xAF48, Data3: 0x513F, Data4: ( 0xBE,0x4D,0xF6,0x45,0xE8,0xC8,0x90,0x05 ))// 33586494-AF48-513F-BE4D-F645E8C89005
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBase2: WindowsFoundation.IID {
+    .init(Data1: 0xD94EE683, Data2: 0xD437, Data3: 0x5523, Data4: ( 0x9C,0x5C,0x11,0xD4,0x80,0x4E,0x47,0x1E ))// D94EE683-D437-5523-9C5C-11D4804E471E
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBaseFactory: WindowsFoundation.IID {
+    .init(Data1: 0x31B9D7B1, Data2: 0x7C38, Data3: 0x5916, Data4: ( 0x99,0xC6,0xC7,0x1F,0x6B,0x01,0x2B,0x1B ))// 31B9D7B1-7C38-5916-99C6-C71F6B012B1B
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBaseStatics: WindowsFoundation.IID {
+    .init(Data1: 0x71A0C438, Data2: 0xF0C2, Data3: 0x5093, Data4: ( 0x89,0x06,0xC1,0xC3,0xC0,0x2D,0xE7,0x91 ))// 71A0C438-F0C2-5093-8906-C1C3C02DE791
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemCollapsedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0xB546F6A1, Data2: 0xC66F, Data3: 0x5DED, Data4: ( 0xB5,0xD7,0xBE,0xD0,0xA2,0x61,0x97,0xE3 ))// B546F6A1-C66F-5DED-B5D7-BED0A26197E3
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemExpandingEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x6F0941BE, Data2: 0xE991, Data3: 0x52F8, Data4: ( 0x83,0x15,0xF0,0x83,0x89,0x49,0x79,0x76 ))// 6F0941BE-E991-52F8-8315-F08389497976
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemFactory: WindowsFoundation.IID {
+    .init(Data1: 0xDE60A001, Data2: 0x9385, Data3: 0x5535, Data4: ( 0x80,0xE1,0x2B,0x68,0xF4,0xBF,0xDE,0x26 ))// DE60A001-9385-5535-80E1-2B68F4BFDE26
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemInvokedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x074CEBAA, Data2: 0x5D05, Data3: 0x547B, Data4: ( 0x8C,0xD6,0xD1,0x9A,0xC2,0xD9,0xBB,0x3B ))// 074CEBAA-5D05-547B-8CD6-D19AC2D9BB3B
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemInvokedEventArgs2: WindowsFoundation.IID {
+    .init(Data1: 0xE1CBB99F, Data2: 0x19EB, Data3: 0x5C7B, Data4: ( 0xB9,0x82,0x85,0x4B,0xB0,0x8D,0x5E,0xB7 ))// E1CBB99F-19EB-5C7B-B982-854BB08D5EB7
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics: WindowsFoundation.IID {
+    .init(Data1: 0x7B6198E5, Data2: 0x0714, Data3: 0x531C, Data4: ( 0xA0,0x56,0x21,0xB3,0xCA,0x40,0xEC,0x1A ))// 7B6198E5-0714-531C-A056-21B3CA40EC1A
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics2: WindowsFoundation.IID {
+    .init(Data1: 0xD49D016F, Data2: 0xABD0, Data3: 0x51F3, Data4: ( 0xAC,0xF0,0x11,0x8E,0xCC,0xEE,0xA7,0x60 ))// D49D016F-ABD0-51F3-ACF0-118ECCEEA760
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics3: WindowsFoundation.IID {
+    .init(Data1: 0x957BEB66, Data2: 0xD33A, Data3: 0x53AA, Data4: ( 0xA5,0x18,0x7D,0x42,0x6B,0xB9,0xB1,0x77 ))// 957BEB66-D33A-53AA-A518-7D426BB9B177
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewPaneClosingEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0xE8643304, Data2: 0x6DB4, Data3: 0x5AF5, Data4: ( 0xBA,0xC2,0x62,0x73,0x3C,0xA0,0x37,0xDA ))// E8643304-6DB4-5AF5-BAC2-62733CA037DA
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewSelectionChangedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x14A064A5, Data2: 0xC79D, Data3: 0x5F63, Data4: ( 0xAC,0x6E,0x1C,0x31,0x3F,0xE6,0x35,0x66 ))// 14A064A5-C79D-5F63-AC6E-1C313FE63566
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewSelectionChangedEventArgs2: WindowsFoundation.IID {
+    .init(Data1: 0xE9B5191F, Data2: 0x1AD1, Data3: 0x5366, Data4: ( 0xBC,0x1A,0x90,0xB9,0x60,0x76,0xD4,0x9E ))// E9B5191F-1AD1-5366-BC1A-90B96076D49E
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics: WindowsFoundation.IID {
+    .init(Data1: 0xDCD04CAF, Data2: 0x1904, Data3: 0x564B, Data4: ( 0xB0,0xDE,0xBA,0xBA,0xFF,0x99,0x62,0xF5 ))// DCD04CAF-1904-564B-B0DE-BABAFF9962F5
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2: WindowsFoundation.IID {
+    .init(Data1: 0x79588150, Data2: 0x4A1B, Data3: 0x5E7C, Data4: ( 0x9F,0x8A,0xEB,0xC8,0x14,0xCE,0x77,0x3D ))// 79588150-4A1B-5E7C-9F8A-EBC814CE773D
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings: WindowsFoundation.IID {
+    .init(Data1: 0xBBD25FA5, Data2: 0x9C08, Data3: 0x5F10, Data4: ( 0xBE,0x20,0xCB,0x4C,0x18,0x99,0xBD,0x9D ))// BBD25FA5-9C08-5F10-BE20-CB4C1899BD9D
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings2: WindowsFoundation.IID {
+    .init(Data1: 0x56BEC72F, Data2: 0x1DE1, Data3: 0x5060, Data4: ( 0xA4,0x4C,0x18,0x78,0x85,0xDF,0x29,0x73 ))// 56BEC72F-1DE1-5060-A44C-187885DF2973
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsFactory: WindowsFoundation.IID {
+    .init(Data1: 0x34FF6C94, Data2: 0x6465, Data3: 0x5F3E, Data4: ( 0xB0,0xA5,0x4F,0x1E,0xEA,0x48,0xE7,0x43 ))// 34FF6C94-6465-5F3E-B0A5-4F1EEA48E743
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics: WindowsFoundation.IID {
+    .init(Data1: 0xBE3A88D6, Data2: 0xD19B, Data3: 0x5543, Data4: ( 0x8B,0x72,0xD4,0x2B,0x45,0x9E,0x72,0xED ))// BE3A88D6-D19B-5543-8B72-D42B459E72ED
+}
+
+private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics2: WindowsFoundation.IID {
+    .init(Data1: 0xC0C06BE3, Data2: 0x9203, Data3: 0x5EEA, Data4: ( 0x91,0xDC,0x5D,0x81,0x2A,0x97,0x02,0xA6 ))// C0C06BE3-9203-5EEA-91DC-5D812A9702A6
 }
 
 private var IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIPage: WindowsFoundation.IID {
@@ -1691,6 +1859,428 @@ public enum __ABI_Microsoft_UI_Xaml_Controls {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAppBarStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_LightDismissOverlayModeProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class IAutoSuggestBox: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox }
+
+        internal func get_MaxSuggestionListHeightImpl() throws -> Double {
+            var value: DOUBLE = 0.0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_MaxSuggestionListHeight(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_MaxSuggestionListHeightImpl(_ value: Double) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_MaxSuggestionListHeight(pThis, value))
+            }
+        }
+
+        internal func get_IsSuggestionListOpenImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsSuggestionListOpen(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_IsSuggestionListOpenImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsSuggestionListOpen(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_TextMemberPathImpl() throws -> String {
+            var value: HSTRING?
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_TextMemberPath(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_TextMemberPathImpl(_ value: String) throws {
+            let _value = try! HString(value)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_TextMemberPath(pThis, _value.get()))
+            }
+        }
+
+        internal func get_TextImpl() throws -> String {
+            var value: HSTRING?
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_Text(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_TextImpl(_ value: String) throws {
+            let _value = try! HString(value)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_Text(pThis, _value.get()))
+            }
+        }
+
+        internal func get_UpdateTextOnSelectImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_UpdateTextOnSelect(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_UpdateTextOnSelectImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_UpdateTextOnSelect(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_PlaceholderTextImpl() throws -> String {
+            var value: HSTRING?
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_PlaceholderText(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_PlaceholderTextImpl(_ value: String) throws {
+            let _value = try! HString(value)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_PlaceholderText(pThis, _value.get()))
+            }
+        }
+
+        internal func get_HeaderImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_Header(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func put_HeaderImpl(_ value: Any?) throws {
+            let valueWrapper = __ABI_.AnyWrapper(value)
+            let _value = try! valueWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_Header(pThis, _value))
+            }
+        }
+
+        internal func get_AutoMaximizeSuggestionAreaImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_AutoMaximizeSuggestionArea(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_AutoMaximizeSuggestionAreaImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_AutoMaximizeSuggestionArea(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_TextBoxStyleImpl() throws -> WinUI.Style? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_TextBoxStyle(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_TextBoxStyleImpl(_ value: WinUI.Style?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_TextBoxStyle(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_QueryIconImpl() throws -> WinUI.IconElement? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_QueryIcon(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_QueryIconImpl(_ value: WinUI.IconElement?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_QueryIcon(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_LightDismissOverlayModeImpl() throws -> WinUI.LightDismissOverlayMode {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CLightDismissOverlayMode = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_LightDismissOverlayMode(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_LightDismissOverlayModeImpl(_ value: WinUI.LightDismissOverlayMode) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_LightDismissOverlayMode(pThis, value))
+            }
+        }
+
+        internal func get_DescriptionImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_Description(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func put_DescriptionImpl(_ value: Any?) throws {
+            let valueWrapper = __ABI_.AnyWrapper(value)
+            let _value = try! valueWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_Description(pThis, _value))
+            }
+        }
+
+        internal func add_SuggestionChosenImpl(_ handler: TypedEventHandler<WinUI.AutoSuggestBox?, WinUI.AutoSuggestBoxSuggestionChosenEventArgs?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_SuggestionChosen(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_SuggestionChosenImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_SuggestionChosen(pThis, token))
+            }
+        }
+
+        internal func add_TextChangedImpl(_ handler: TypedEventHandler<WinUI.AutoSuggestBox?, WinUI.AutoSuggestBoxTextChangedEventArgs?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_TextChanged(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_TextChangedImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_TextChanged(pThis, token))
+            }
+        }
+
+        internal func add_QuerySubmittedImpl(_ handler: TypedEventHandler<WinUI.AutoSuggestBox?, WinUI.AutoSuggestBoxQuerySubmittedEventArgs?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_QuerySubmitted(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_QuerySubmittedImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_QuerySubmitted(pThis, token))
+            }
+        }
+
+    }
+
+    public class IAutoSuggestBoxQuerySubmittedEventArgs: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxQuerySubmittedEventArgs }
+
+        internal func get_QueryTextImpl() throws -> String {
+            var value: HSTRING?
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxQuerySubmittedEventArgs.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_QueryText(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func get_ChosenSuggestionImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxQuerySubmittedEventArgs.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_ChosenSuggestion(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+    }
+
+    public class IAutoSuggestBoxStatics: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics }
+
+        internal func get_MaxSuggestionListHeightPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MaxSuggestionListHeightProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_IsSuggestionListOpenPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsSuggestionListOpenProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_TextMemberPathPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_TextMemberPathProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_TextPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_TextProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_UpdateTextOnSelectPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_UpdateTextOnSelectProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_PlaceholderTextPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PlaceholderTextProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_HeaderPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_HeaderProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_AutoMaximizeSuggestionAreaPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_AutoMaximizeSuggestionAreaProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_TextBoxStylePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_TextBoxStyleProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_QueryIconPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_QueryIconProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_LightDismissOverlayModePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_LightDismissOverlayModeProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_DescriptionPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_DescriptionProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class IAutoSuggestBoxSuggestionChosenEventArgs: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxSuggestionChosenEventArgs }
+
+        internal func get_SelectedItemImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxSuggestionChosenEventArgs.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SelectedItem(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+    }
+
+    public class IAutoSuggestBoxTextChangedEventArgs: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxTextChangedEventArgs }
+
+        internal func get_ReasonImpl() throws -> WinUI.AutoSuggestionBoxTextChangeReason {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CAutoSuggestionBoxTextChangeReason = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxTextChangedEventArgs.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_Reason(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_ReasonImpl(_ value: WinUI.AutoSuggestionBoxTextChangeReason) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxTextChangedEventArgs.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_Reason(pThis, value))
+            }
+        }
+
+        internal func CheckCurrentImpl() throws -> Bool {
+            var result: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxTextChangedEventArgs.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.CheckCurrent(pThis, &result))
+            }
+            return .init(from: result)
+        }
+
+    }
+
+    public class IAutoSuggestBoxTextChangedEventArgsStatics: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxTextChangedEventArgsStatics }
+
+        internal func get_ReasonPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxTextChangedEventArgsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_ReasonProperty(pThis, &valueAbi))
                 }
             }
             return .from(abi: value)
@@ -7343,6 +7933,174 @@ public enum __ABI_Microsoft_UI_Xaml_Controls {
 
     }
 
+    public class IInfoBadge: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadge }
+
+        internal func get_ValueImpl() throws -> Int32 {
+            var value: INT32 = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadge.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_ValueImpl(_ value: Int32) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadge.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_Value(pThis, value))
+            }
+        }
+
+        internal func get_IconSourceImpl() throws -> WinUI.IconSource? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadge.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IconSource(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_IconSourceImpl(_ value: WinUI.IconSource?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadge.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IconSource(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_TemplateSettingsImpl() throws -> WinUI.InfoBadgeTemplateSettings? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadge.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_TemplateSettings(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class IInfoBadgeFactory: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeFactory }
+
+        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<WinUI.InfoBadge.Composable>?, _ innerInterface: inout WindowsFoundation.IInspectable?) throws -> IInfoBadge {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                let _baseInterface = baseInterface?.toIInspectableABI { $0 }
+                let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
+                    _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeFactory.self) { pThis in
+                        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, _baseInterface, &_innerInterfaceAbi, &valueAbi))
+                    }
+                }
+                innerInterface = WindowsFoundation.IInspectable(_innerInterface!)
+            }
+            return IInfoBadge(value!)
+        }
+
+    }
+
+    public class IInfoBadgeStatics: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeStatics }
+
+        internal func get_ValuePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_ValueProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_IconSourcePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IconSourceProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_TemplateSettingsPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_TemplateSettingsProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class IInfoBadgeTemplateSettings: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettings }
+
+        internal func get_InfoBadgeCornerRadiusImpl() throws -> WinUI.CornerRadius {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CCornerRadius = .init()
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_InfoBadgeCornerRadius(pThis, &value))
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_InfoBadgeCornerRadiusImpl(_ value: WinUI.CornerRadius) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_InfoBadgeCornerRadius(pThis, .from(swift: value)))
+            }
+        }
+
+        internal func get_IconElementImpl() throws -> WinUI.IconElement? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettings.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IconElement(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_IconElementImpl(_ value: WinUI.IconElement?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IconElement(pThis, RawPointer(value)))
+            }
+        }
+
+    }
+
+    public class IInfoBadgeTemplateSettingsFactory: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettingsFactory }
+
+        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<WinUI.InfoBadgeTemplateSettings.Composable>?, _ innerInterface: inout WindowsFoundation.IInspectable?) throws -> IInfoBadgeTemplateSettings {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                let _baseInterface = baseInterface?.toIInspectableABI { $0 }
+                let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
+                    _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettingsFactory.self) { pThis in
+                        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, _baseInterface, &_innerInterfaceAbi, &valueAbi))
+                    }
+                }
+                innerInterface = WindowsFoundation.IInspectable(_innerInterface!)
+            }
+            return IInfoBadgeTemplateSettings(value!)
+        }
+
+    }
+
+    public class IInfoBadgeTemplateSettingsStatics: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettingsStatics }
+
+        internal func get_InfoBadgeCornerRadiusPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_InfoBadgeCornerRadiusProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_IconElementPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IconElementProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
     public class IInfoBar: WindowsFoundation.IInspectable {
         override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBar }
 
@@ -11652,6 +12410,1758 @@ public enum __ABI_Microsoft_UI_Xaml_Controls {
     )
 
     public typealias INavigateWrapper = InterfaceWrapperBase<__IMPL_Microsoft_UI_Xaml_Controls.INavigateBridge>
+    public class INavigationView: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView }
+
+        internal func get_IsPaneOpenImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsPaneOpen(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_IsPaneOpenImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsPaneOpen(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_CompactModeThresholdWidthImpl() throws -> Double {
+            var value: DOUBLE = 0.0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_CompactModeThresholdWidth(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_CompactModeThresholdWidthImpl(_ value: Double) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_CompactModeThresholdWidth(pThis, value))
+            }
+        }
+
+        internal func get_ExpandedModeThresholdWidthImpl() throws -> Double {
+            var value: DOUBLE = 0.0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_ExpandedModeThresholdWidth(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_ExpandedModeThresholdWidthImpl(_ value: Double) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_ExpandedModeThresholdWidth(pThis, value))
+            }
+        }
+
+        internal func get_FooterMenuItemsImpl() throws -> WindowsFoundation.AnyIVector<Any?>? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_FooterMenuItems(pThis, &valueAbi))
+                }
+            }
+            return WinUI.__x_ABI_C__FIVector_1_IInspectableWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func get_FooterMenuItemsSourceImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_FooterMenuItemsSource(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func put_FooterMenuItemsSourceImpl(_ value: Any?) throws {
+            let valueWrapper = __ABI_.AnyWrapper(value)
+            let _value = try! valueWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_FooterMenuItemsSource(pThis, _value))
+            }
+        }
+
+        internal func get_PaneFooterImpl() throws -> WinUI.UIElement? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneFooter(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_PaneFooterImpl(_ value: WinUI.UIElement?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_PaneFooter(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_HeaderImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_Header(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func put_HeaderImpl(_ value: Any?) throws {
+            let valueWrapper = __ABI_.AnyWrapper(value)
+            let _value = try! valueWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_Header(pThis, _value))
+            }
+        }
+
+        internal func get_HeaderTemplateImpl() throws -> WinUI.DataTemplate? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_HeaderTemplate(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_HeaderTemplateImpl(_ value: WinUI.DataTemplate?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_HeaderTemplate(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_DisplayModeImpl() throws -> WinUI.NavigationViewDisplayMode {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewDisplayMode = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayMode(pThis, &value))
+            }
+            return value
+        }
+
+        internal func get_IsSettingsVisibleImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsSettingsVisible(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_IsSettingsVisibleImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsSettingsVisible(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_IsPaneToggleButtonVisibleImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsPaneToggleButtonVisible(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_IsPaneToggleButtonVisibleImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsPaneToggleButtonVisible(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_AlwaysShowHeaderImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_AlwaysShowHeader(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_AlwaysShowHeaderImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_AlwaysShowHeader(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_CompactPaneLengthImpl() throws -> Double {
+            var value: DOUBLE = 0.0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_CompactPaneLength(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_CompactPaneLengthImpl(_ value: Double) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_CompactPaneLength(pThis, value))
+            }
+        }
+
+        internal func get_OpenPaneLengthImpl() throws -> Double {
+            var value: DOUBLE = 0.0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_OpenPaneLength(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_OpenPaneLengthImpl(_ value: Double) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_OpenPaneLength(pThis, value))
+            }
+        }
+
+        internal func get_PaneToggleButtonStyleImpl() throws -> WinUI.Style? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneToggleButtonStyle(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_PaneToggleButtonStyleImpl(_ value: WinUI.Style?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_PaneToggleButtonStyle(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_SelectedItemImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SelectedItem(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func put_SelectedItemImpl(_ value: Any?) throws {
+            let valueWrapper = __ABI_.AnyWrapper(value)
+            let _value = try! valueWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_SelectedItem(pThis, _value))
+            }
+        }
+
+        internal func get_MenuItemsImpl() throws -> WindowsFoundation.AnyIVector<Any?>? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItems(pThis, &valueAbi))
+                }
+            }
+            return WinUI.__x_ABI_C__FIVector_1_IInspectableWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func get_MenuItemsSourceImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemsSource(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func put_MenuItemsSourceImpl(_ value: Any?) throws {
+            let valueWrapper = __ABI_.AnyWrapper(value)
+            let _value = try! valueWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_MenuItemsSource(pThis, _value))
+            }
+        }
+
+        internal func get_SettingsItemImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SettingsItem(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func get_AutoSuggestBoxImpl() throws -> WinUI.AutoSuggestBox? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_AutoSuggestBox(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_AutoSuggestBoxImpl(_ value: WinUI.AutoSuggestBox?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_AutoSuggestBox(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_MenuItemTemplateImpl() throws -> WinUI.DataTemplate? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemTemplate(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_MenuItemTemplateImpl(_ value: WinUI.DataTemplate?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_MenuItemTemplate(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_MenuItemTemplateSelectorImpl() throws -> WinUI.DataTemplateSelector? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemTemplateSelector(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_MenuItemTemplateSelectorImpl(_ value: WinUI.DataTemplateSelector?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_MenuItemTemplateSelector(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_MenuItemContainerStyleImpl() throws -> WinUI.Style? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemContainerStyle(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_MenuItemContainerStyleImpl(_ value: WinUI.Style?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_MenuItemContainerStyle(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_MenuItemContainerStyleSelectorImpl() throws -> WinUI.StyleSelector? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemContainerStyleSelector(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_MenuItemContainerStyleSelectorImpl(_ value: WinUI.StyleSelector?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_MenuItemContainerStyleSelector(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func MenuItemFromContainerImpl(_ container: WinUI.DependencyObject?) throws -> Any? {
+            let (result) = try ComPtrs.initialize { resultAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.MenuItemFromContainer(pThis, RawPointer(container), &resultAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: result)
+        }
+
+        internal func ContainerFromMenuItemImpl(_ item: Any?) throws -> WinUI.DependencyObject? {
+            let (result) = try ComPtrs.initialize { resultAbi in
+                let itemWrapper = __ABI_.AnyWrapper(item)
+                let _item = try! itemWrapper?.toABI { $0 }
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.ContainerFromMenuItem(pThis, _item, &resultAbi))
+                }
+            }
+            return .from(abi: result)
+        }
+
+        internal func add_SelectionChangedImpl(_ handler: TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewSelectionChangedEventArgs?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_SelectionChanged(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_SelectionChangedImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_SelectionChanged(pThis, token))
+            }
+        }
+
+        internal func add_ItemInvokedImpl(_ handler: TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewItemInvokedEventArgs?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_ItemInvoked(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_ItemInvokedImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_ItemInvoked(pThis, token))
+            }
+        }
+
+        internal func add_DisplayModeChangedImpl(_ handler: TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewDisplayModeChangedEventArgs?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_DisplayModeChanged(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_DisplayModeChangedImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_DisplayModeChanged(pThis, token))
+            }
+        }
+
+        internal func get_IsTitleBarAutoPaddingEnabledImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsTitleBarAutoPaddingEnabled(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_IsTitleBarAutoPaddingEnabledImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsTitleBarAutoPaddingEnabled(pThis, .init(from: value)))
+            }
+        }
+
+    }
+
+    public class INavigationView2: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2 }
+
+        internal func get_IsBackButtonVisibleImpl() throws -> WinUI.NavigationViewBackButtonVisible {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewBackButtonVisible = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsBackButtonVisible(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_IsBackButtonVisibleImpl(_ value: WinUI.NavigationViewBackButtonVisible) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsBackButtonVisible(pThis, value))
+            }
+        }
+
+        internal func get_IsBackEnabledImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsBackEnabled(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_IsBackEnabledImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsBackEnabled(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_PaneTitleImpl() throws -> String {
+            var value: HSTRING?
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneTitle(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_PaneTitleImpl(_ value: String) throws {
+            let _value = try! HString(value)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_PaneTitle(pThis, _value.get()))
+            }
+        }
+
+        internal func add_BackRequestedImpl(_ handler: TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewBackRequestedEventArgs?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_BackRequested(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_BackRequestedImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_BackRequested(pThis, token))
+            }
+        }
+
+        internal func add_PaneClosedImpl(_ handler: TypedEventHandler<WinUI.NavigationView?, Any?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_PaneClosed(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_PaneClosedImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_PaneClosed(pThis, token))
+            }
+        }
+
+        internal func add_PaneClosingImpl(_ handler: TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewPaneClosingEventArgs?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_PaneClosing(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_PaneClosingImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_PaneClosing(pThis, token))
+            }
+        }
+
+        internal func add_PaneOpenedImpl(_ handler: TypedEventHandler<WinUI.NavigationView?, Any?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_PaneOpened(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_PaneOpenedImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_PaneOpened(pThis, token))
+            }
+        }
+
+        internal func add_PaneOpeningImpl(_ handler: TypedEventHandler<WinUI.NavigationView?, Any?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_PaneOpening(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_PaneOpeningImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_PaneOpening(pThis, token))
+            }
+        }
+
+        internal func get_PaneDisplayModeImpl() throws -> WinUI.NavigationViewPaneDisplayMode {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewPaneDisplayMode = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneDisplayMode(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_PaneDisplayModeImpl(_ value: WinUI.NavigationViewPaneDisplayMode) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_PaneDisplayMode(pThis, value))
+            }
+        }
+
+        internal func get_PaneHeaderImpl() throws -> WinUI.UIElement? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneHeader(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_PaneHeaderImpl(_ value: WinUI.UIElement?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_PaneHeader(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_PaneCustomContentImpl() throws -> WinUI.UIElement? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneCustomContent(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_PaneCustomContentImpl(_ value: WinUI.UIElement?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_PaneCustomContent(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_ContentOverlayImpl() throws -> WinUI.UIElement? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_ContentOverlay(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_ContentOverlayImpl(_ value: WinUI.UIElement?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_ContentOverlay(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_IsPaneVisibleImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsPaneVisible(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_IsPaneVisibleImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsPaneVisible(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_SelectionFollowsFocusImpl() throws -> WinUI.NavigationViewSelectionFollowsFocus {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewSelectionFollowsFocus = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_SelectionFollowsFocus(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_SelectionFollowsFocusImpl(_ value: WinUI.NavigationViewSelectionFollowsFocus) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_SelectionFollowsFocus(pThis, value))
+            }
+        }
+
+        internal func get_TemplateSettingsImpl() throws -> WinUI.NavigationViewTemplateSettings? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_TemplateSettings(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_ShoulderNavigationEnabledImpl() throws -> WinUI.NavigationViewShoulderNavigationEnabled {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewShoulderNavigationEnabled = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_ShoulderNavigationEnabled(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_ShoulderNavigationEnabledImpl(_ value: WinUI.NavigationViewShoulderNavigationEnabled) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_ShoulderNavigationEnabled(pThis, value))
+            }
+        }
+
+        internal func get_OverflowLabelModeImpl() throws -> WinUI.NavigationViewOverflowLabelMode {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewOverflowLabelMode = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_OverflowLabelMode(pThis, &value))
+            }
+            return value
+        }
+
+        internal func put_OverflowLabelModeImpl(_ value: WinUI.NavigationViewOverflowLabelMode) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_OverflowLabelMode(pThis, value))
+            }
+        }
+
+        internal func add_ExpandingImpl(_ handler: TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewItemExpandingEventArgs?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_Expanding(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_ExpandingImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_Expanding(pThis, token))
+            }
+        }
+
+        internal func add_CollapsedImpl(_ handler: TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewItemCollapsedEventArgs?>?) throws -> EventRegistrationToken {
+            var token: EventRegistrationToken = .init()
+            let handlerWrapper = WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsWrapper(handler)
+            let _handler = try! handlerWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.add_Collapsed(pThis, _handler, &token))
+            }
+            return token
+        }
+
+        internal func remove_CollapsedImpl(_ token: EventRegistrationToken) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.remove_Collapsed(pThis, token))
+            }
+        }
+
+        internal func ExpandImpl(_ item: WinUI.NavigationViewItem?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.Expand(pThis, RawPointer(item)))
+            }
+        }
+
+        internal func CollapseImpl(_ item: WinUI.NavigationViewItem?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.Collapse(pThis, RawPointer(item)))
+            }
+        }
+
+    }
+
+    public class INavigationViewBackRequestedEventArgs: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewBackRequestedEventArgs }
+
+    }
+
+    public class INavigationViewDisplayModeChangedEventArgs: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewDisplayModeChangedEventArgs }
+
+        internal func get_DisplayModeImpl() throws -> WinUI.NavigationViewDisplayMode {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewDisplayMode = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewDisplayModeChangedEventArgs.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayMode(pThis, &value))
+            }
+            return value
+        }
+
+    }
+
+    public class INavigationViewFactory: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewFactory }
+
+        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<WinUI.NavigationView.Composable>?, _ innerInterface: inout WindowsFoundation.IInspectable?) throws -> INavigationView {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                let _baseInterface = baseInterface?.toIInspectableABI { $0 }
+                let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
+                    _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewFactory.self) { pThis in
+                        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, _baseInterface, &_innerInterfaceAbi, &valueAbi))
+                    }
+                }
+                innerInterface = WindowsFoundation.IInspectable(_innerInterface!)
+            }
+            return INavigationView(value!)
+        }
+
+    }
+
+    public class INavigationViewItem: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem }
+
+        internal func get_IconImpl() throws -> WinUI.IconElement? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_Icon(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_IconImpl(_ value: WinUI.IconElement?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_Icon(pThis, RawPointer(value)))
+            }
+        }
+
+        internal func get_CompactPaneLengthImpl() throws -> Double {
+            var value: DOUBLE = 0.0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_CompactPaneLength(pThis, &value))
+            }
+            return value
+        }
+
+    }
+
+    public class INavigationViewItem2: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2 }
+
+        internal func get_SelectsOnInvokedImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_SelectsOnInvoked(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_SelectsOnInvokedImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_SelectsOnInvoked(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_IsExpandedImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsExpanded(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_IsExpandedImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsExpanded(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_HasUnrealizedChildrenImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasUnrealizedChildren(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_HasUnrealizedChildrenImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_HasUnrealizedChildren(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_IsChildSelectedImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsChildSelected(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_IsChildSelectedImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsChildSelected(pThis, .init(from: value)))
+            }
+        }
+
+        internal func get_MenuItemsImpl() throws -> WindowsFoundation.AnyIVector<Any?>? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItems(pThis, &valueAbi))
+                }
+            }
+            return WinUI.__x_ABI_C__FIVector_1_IInspectableWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func get_MenuItemsSourceImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemsSource(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func put_MenuItemsSourceImpl(_ value: Any?) throws {
+            let valueWrapper = __ABI_.AnyWrapper(value)
+            let _value = try! valueWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_MenuItemsSource(pThis, _value))
+            }
+        }
+
+    }
+
+    public class INavigationViewItem3: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem3 }
+
+        internal func get_InfoBadgeImpl() throws -> WinUI.InfoBadge? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem3.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_InfoBadge(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_InfoBadgeImpl(_ value: WinUI.InfoBadge?) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem3.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_InfoBadge(pThis, RawPointer(value)))
+            }
+        }
+
+    }
+
+    public class INavigationViewItemBase: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBase }
+
+    }
+
+    public class INavigationViewItemBase2: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBase2 }
+
+        internal func get_IsSelectedImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBase2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsSelected(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_IsSelectedImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBase2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_IsSelected(pThis, .init(from: value)))
+            }
+        }
+
+    }
+
+    public class INavigationViewItemBaseFactory: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBaseFactory }
+
+    }
+
+    public class INavigationViewItemBaseStatics: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBaseStatics }
+
+        internal func get_IsSelectedPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBaseStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsSelectedProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class INavigationViewItemCollapsedEventArgs: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemCollapsedEventArgs }
+
+        internal func get_CollapsedItemContainerImpl() throws -> WinUI.NavigationViewItemBase? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemCollapsedEventArgs.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_CollapsedItemContainer(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_CollapsedItemImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemCollapsedEventArgs.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_CollapsedItem(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+    }
+
+    public class INavigationViewItemExpandingEventArgs: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemExpandingEventArgs }
+
+        internal func get_ExpandingItemContainerImpl() throws -> WinUI.NavigationViewItemBase? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemExpandingEventArgs.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_ExpandingItemContainer(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_ExpandingItemImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemExpandingEventArgs.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_ExpandingItem(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+    }
+
+    public class INavigationViewItemFactory: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemFactory }
+
+        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<WinUI.NavigationViewItem.Composable>?, _ innerInterface: inout WindowsFoundation.IInspectable?) throws -> INavigationViewItem {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                let _baseInterface = baseInterface?.toIInspectableABI { $0 }
+                let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
+                    _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemFactory.self) { pThis in
+                        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, _baseInterface, &_innerInterfaceAbi, &valueAbi))
+                    }
+                }
+                innerInterface = WindowsFoundation.IInspectable(_innerInterface!)
+            }
+            return INavigationViewItem(value!)
+        }
+
+    }
+
+    public class INavigationViewItemInvokedEventArgs: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemInvokedEventArgs }
+
+        internal func get_InvokedItemImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemInvokedEventArgs.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_InvokedItem(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func get_IsSettingsInvokedImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemInvokedEventArgs.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsSettingsInvoked(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+    }
+
+    public class INavigationViewItemInvokedEventArgs2: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemInvokedEventArgs2 }
+
+        internal func get_InvokedItemContainerImpl() throws -> WinUI.NavigationViewItemBase? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemInvokedEventArgs2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_InvokedItemContainer(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_RecommendedNavigationTransitionInfoImpl() throws -> WinUI.NavigationTransitionInfo? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemInvokedEventArgs2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_RecommendedNavigationTransitionInfo(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class INavigationViewItemStatics: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics }
+
+        internal func get_IconPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IconProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_CompactPaneLengthPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_CompactPaneLengthProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class INavigationViewItemStatics2: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics2 }
+
+        internal func get_SelectsOnInvokedPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SelectsOnInvokedProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_IsExpandedPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsExpandedProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_HasUnrealizedChildrenPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasUnrealizedChildrenProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_IsChildSelectedPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsChildSelectedProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_MenuItemsPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemsProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_MenuItemsSourcePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemsSourceProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class INavigationViewItemStatics3: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics3 }
+
+        internal func get_InfoBadgePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemStatics3.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_InfoBadgeProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class INavigationViewPaneClosingEventArgs: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewPaneClosingEventArgs }
+
+        internal func get_CancelImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewPaneClosingEventArgs.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_Cancel(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_CancelImpl(_ value: Bool) throws {
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewPaneClosingEventArgs.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_Cancel(pThis, .init(from: value)))
+            }
+        }
+
+    }
+
+    public class INavigationViewSelectionChangedEventArgs: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewSelectionChangedEventArgs }
+
+        internal func get_SelectedItemImpl() throws -> Any? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewSelectionChangedEventArgs.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SelectedItem(pThis, &valueAbi))
+                }
+            }
+            return __ABI_.AnyWrapper.unwrapFrom(abi: value)
+        }
+
+        internal func get_IsSettingsSelectedImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewSelectionChangedEventArgs.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsSettingsSelected(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+    }
+
+    public class INavigationViewSelectionChangedEventArgs2: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewSelectionChangedEventArgs2 }
+
+        internal func get_SelectedItemContainerImpl() throws -> WinUI.NavigationViewItemBase? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewSelectionChangedEventArgs2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SelectedItemContainer(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_RecommendedNavigationTransitionInfoImpl() throws -> WinUI.NavigationTransitionInfo? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewSelectionChangedEventArgs2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_RecommendedNavigationTransitionInfo(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class INavigationViewStatics: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics }
+
+        internal func get_IsPaneOpenPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsPaneOpenProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_CompactModeThresholdWidthPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_CompactModeThresholdWidthProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_ExpandedModeThresholdWidthPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_ExpandedModeThresholdWidthProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_FooterMenuItemsPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_FooterMenuItemsProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_FooterMenuItemsSourcePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_FooterMenuItemsSourceProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_PaneFooterPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneFooterProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_HeaderPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_HeaderProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_HeaderTemplatePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_HeaderTemplateProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_DisplayModePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayModeProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_IsSettingsVisiblePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsSettingsVisibleProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_IsPaneToggleButtonVisiblePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsPaneToggleButtonVisibleProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_AlwaysShowHeaderPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_AlwaysShowHeaderProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_CompactPaneLengthPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_CompactPaneLengthProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_OpenPaneLengthPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_OpenPaneLengthProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_PaneToggleButtonStylePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneToggleButtonStyleProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_MenuItemsPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemsProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_MenuItemsSourcePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemsSourceProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_SelectedItemPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SelectedItemProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_SettingsItemPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SettingsItemProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_AutoSuggestBoxPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_AutoSuggestBoxProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_MenuItemTemplatePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemTemplateProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_MenuItemTemplateSelectorPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemTemplateSelectorProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_MenuItemContainerStylePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemContainerStyleProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_MenuItemContainerStyleSelectorPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_MenuItemContainerStyleSelectorProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_IsTitleBarAutoPaddingEnabledPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsTitleBarAutoPaddingEnabledProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class INavigationViewStatics2: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2 }
+
+        internal func get_IsBackButtonVisiblePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsBackButtonVisibleProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_IsBackEnabledPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsBackEnabledProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_PaneTitlePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneTitleProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_PaneDisplayModePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneDisplayModeProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_PaneHeaderPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneHeaderProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_PaneCustomContentPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneCustomContentProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_ContentOverlayPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_ContentOverlayProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_IsPaneVisiblePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsPaneVisibleProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_SelectionFollowsFocusPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SelectionFollowsFocusProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_TemplateSettingsPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_TemplateSettingsProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_ShoulderNavigationEnabledPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_ShoulderNavigationEnabledProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_OverflowLabelModePropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_OverflowLabelModeProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class INavigationViewTemplateSettings: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings }
+
+        internal func get_TopPaddingImpl() throws -> Double {
+            var value: DOUBLE = 0.0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_TopPadding(pThis, &value))
+            }
+            return value
+        }
+
+        internal func get_OverflowButtonVisibilityImpl() throws -> WinUI.Visibility {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CVisibility = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_OverflowButtonVisibility(pThis, &value))
+            }
+            return value
+        }
+
+        internal func get_PaneToggleButtonVisibilityImpl() throws -> WinUI.Visibility {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CVisibility = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneToggleButtonVisibility(pThis, &value))
+            }
+            return value
+        }
+
+        internal func get_BackButtonVisibilityImpl() throws -> WinUI.Visibility {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CVisibility = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_BackButtonVisibility(pThis, &value))
+            }
+            return value
+        }
+
+        internal func get_TopPaneVisibilityImpl() throws -> WinUI.Visibility {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CVisibility = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_TopPaneVisibility(pThis, &value))
+            }
+            return value
+        }
+
+        internal func get_LeftPaneVisibilityImpl() throws -> WinUI.Visibility {
+            var value: __x_ABI_CMicrosoft_CUI_CXaml_CVisibility = .init(0)
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_LeftPaneVisibility(pThis, &value))
+            }
+            return value
+        }
+
+        internal func get_SingleSelectionFollowsFocusImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_SingleSelectionFollowsFocus(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func get_PaneToggleButtonWidthImpl() throws -> Double {
+            var value: DOUBLE = 0.0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneToggleButtonWidth(pThis, &value))
+            }
+            return value
+        }
+
+        internal func get_SmallerPaneToggleButtonWidthImpl() throws -> Double {
+            var value: DOUBLE = 0.0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_SmallerPaneToggleButtonWidth(pThis, &value))
+            }
+            return value
+        }
+
+    }
+
+    public class INavigationViewTemplateSettings2: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings2 }
+
+        internal func get_OpenPaneLengthImpl() throws -> Double {
+            var value: DOUBLE = 0.0
+            _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings2.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_OpenPaneLength(pThis, &value))
+            }
+            return value
+        }
+
+    }
+
+    public class INavigationViewTemplateSettingsFactory: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsFactory }
+
+        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<WinUI.NavigationViewTemplateSettings.Composable>?, _ innerInterface: inout WindowsFoundation.IInspectable?) throws -> INavigationViewTemplateSettings {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                let _baseInterface = baseInterface?.toIInspectableABI { $0 }
+                let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
+                    _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsFactory.self) { pThis in
+                        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, _baseInterface, &_innerInterfaceAbi, &valueAbi))
+                    }
+                }
+                innerInterface = WindowsFoundation.IInspectable(_innerInterface!)
+            }
+            return INavigationViewTemplateSettings(value!)
+        }
+
+    }
+
+    public class INavigationViewTemplateSettingsStatics: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics }
+
+        internal func get_TopPaddingPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_TopPaddingProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_OverflowButtonVisibilityPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_OverflowButtonVisibilityProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_PaneToggleButtonVisibilityPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneToggleButtonVisibilityProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_BackButtonVisibilityPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_BackButtonVisibilityProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_TopPaneVisibilityPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_TopPaneVisibilityProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_LeftPaneVisibilityPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_LeftPaneVisibilityProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_SingleSelectionFollowsFocusPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SingleSelectionFollowsFocusProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_PaneToggleButtonWidthPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_PaneToggleButtonWidthProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+        internal func get_SmallerPaneToggleButtonWidthPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_SmallerPaneToggleButtonWidthProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
+    public class INavigationViewTemplateSettingsStatics2: WindowsFoundation.IInspectable {
+        override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics2 }
+
+        internal func get_OpenPaneLengthPropertyImpl() throws -> WinUI.DependencyProperty? {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                _ = try perform(as: __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettingsStatics2.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.get_OpenPaneLengthProperty(pThis, &valueAbi))
+                }
+            }
+            return .from(abi: value)
+        }
+
+    }
+
     public class IPage: WindowsFoundation.IInspectable {
         override public class var IID: WindowsFoundation.IID { IID___x_ABI_CMicrosoft_CUI_CXaml_CControls_CIPage }
 

--- a/Sources/WinUI/Generated/Microsoft.UI.Xaml.Controls.swift
+++ b/Sources/WinUI/Generated/Microsoft.UI.Xaml.Controls.swift
@@ -8,6 +8,8 @@ import CWinRT
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.appbarcloseddisplaymode)
 public typealias AppBarClosedDisplayMode = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CAppBarClosedDisplayMode
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestionboxtextchangereason)
+public typealias AutoSuggestionBoxTextChangeReason = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CAutoSuggestionBoxTextChangeReason
 /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.backgroundsizing)
 public typealias BackgroundSizing = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CBackgroundSizing
 /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.candidatewindowalignment)
@@ -44,6 +46,18 @@ public typealias LightDismissOverlayMode = __x_ABI_CMicrosoft_CUI_CXaml_CControl
 public typealias ListViewReorderMode = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CListViewReorderMode
 /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.listviewselectionmode)
 public typealias ListViewSelectionMode = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CListViewSelectionMode
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewbackbuttonvisible)
+public typealias NavigationViewBackButtonVisible = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewBackButtonVisible
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewdisplaymode)
+public typealias NavigationViewDisplayMode = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewDisplayMode
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewoverflowlabelmode)
+public typealias NavigationViewOverflowLabelMode = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewOverflowLabelMode
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewpanedisplaymode)
+public typealias NavigationViewPaneDisplayMode = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewPaneDisplayMode
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewselectionfollowsfocus)
+public typealias NavigationViewSelectionFollowsFocus = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewSelectionFollowsFocus
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewshouldernavigationenabled)
+public typealias NavigationViewShoulderNavigationEnabled = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewShoulderNavigationEnabled
 /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.orientation)
 public typealias Orientation = __x_ABI_CMicrosoft_CUI_CXaml_CControls_COrientation
 /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.passwordrevealmode)
@@ -326,6 +340,353 @@ open class AppBar : WinUI.ContentControl {
     deinit {
         _default = nil
         _IAppBarOverrides = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox)
+public final class AutoSuggestBox : WinUI.ItemsControl {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IAutoSuggestBox
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox>?) -> AutoSuggestBox? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    override public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi: fromAbi)
+    }
+
+    override public init() {
+        super.init(fromAbi: try! RoActivateInstance(HString("Microsoft.UI.Xaml.Controls.AutoSuggestBox")))
+    }
+
+    private static let _IAutoSuggestBoxStatics: __ABI_Microsoft_UI_Xaml_Controls.IAutoSuggestBoxStatics = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.AutoSuggestBox"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.automaximizesuggestionareaproperty)
+    public static var autoMaximizeSuggestionAreaProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_AutoMaximizeSuggestionAreaPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.descriptionproperty)
+    public static var descriptionProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_DescriptionPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.headerproperty)
+    public static var headerProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_HeaderPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.issuggestionlistopenproperty)
+    public static var isSuggestionListOpenProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_IsSuggestionListOpenPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.lightdismissoverlaymodeproperty)
+    public static var lightDismissOverlayModeProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_LightDismissOverlayModePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.maxsuggestionlistheightproperty)
+    public static var maxSuggestionListHeightProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_MaxSuggestionListHeightPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.placeholdertextproperty)
+    public static var placeholderTextProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_PlaceholderTextPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.queryiconproperty)
+    public static var queryIconProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_QueryIconPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.textboxstyleproperty)
+    public static var textBoxStyleProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_TextBoxStylePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.textmemberpathproperty)
+    public static var textMemberPathProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_TextMemberPathPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.textproperty)
+    public static var textProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_TextPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.updatetextonselectproperty)
+    public static var updateTextOnSelectProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxStatics.get_UpdateTextOnSelectPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.automaximizesuggestionarea)
+    public var autoMaximizeSuggestionArea : Bool {
+        get { try! _default.get_AutoMaximizeSuggestionAreaImpl() }
+        set { try! _default.put_AutoMaximizeSuggestionAreaImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.description)
+    public var description : Any! {
+        get { try! _default.get_DescriptionImpl() }
+        set { try! _default.put_DescriptionImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.header)
+    public var header : Any! {
+        get { try! _default.get_HeaderImpl() }
+        set { try! _default.put_HeaderImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.issuggestionlistopen)
+    public var isSuggestionListOpen : Bool {
+        get { try! _default.get_IsSuggestionListOpenImpl() }
+        set { try! _default.put_IsSuggestionListOpenImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.lightdismissoverlaymode)
+    public var lightDismissOverlayMode : LightDismissOverlayMode {
+        get { try! _default.get_LightDismissOverlayModeImpl() }
+        set { try! _default.put_LightDismissOverlayModeImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.maxsuggestionlistheight)
+    public var maxSuggestionListHeight : Double {
+        get { try! _default.get_MaxSuggestionListHeightImpl() }
+        set { try! _default.put_MaxSuggestionListHeightImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.placeholdertext)
+    public var placeholderText : String {
+        get { try! _default.get_PlaceholderTextImpl() }
+        set { try! _default.put_PlaceholderTextImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.queryicon)
+    public var queryIcon : IconElement! {
+        get { try! _default.get_QueryIconImpl() }
+        set { try! _default.put_QueryIconImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.text)
+    public var text : String {
+        get { try! _default.get_TextImpl() }
+        set { try! _default.put_TextImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.textboxstyle)
+    public var textBoxStyle : WinUI.Style! {
+        get { try! _default.get_TextBoxStyleImpl() }
+        set { try! _default.put_TextBoxStyleImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.textmemberpath)
+    public var textMemberPath : String {
+        get { try! _default.get_TextMemberPathImpl() }
+        set { try! _default.put_TextMemberPathImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.updatetextonselect)
+    public var updateTextOnSelect : Bool {
+        get { try! _default.get_UpdateTextOnSelectImpl() }
+        set { try! _default.put_UpdateTextOnSelectImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.querysubmitted)
+    public lazy var querySubmitted : Event<TypedEventHandler<AutoSuggestBox?, AutoSuggestBoxQuerySubmittedEventArgs?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._default else { return .init() }
+          return try! this.add_QuerySubmittedImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._default.remove_QuerySubmittedImpl($0)
+       }
+      )
+    }()
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.suggestionchosen)
+    public lazy var suggestionChosen : Event<TypedEventHandler<AutoSuggestBox?, AutoSuggestBoxSuggestionChosenEventArgs?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._default else { return .init() }
+          return try! this.add_SuggestionChosenImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._default.remove_SuggestionChosenImpl($0)
+       }
+      )
+    }()
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestbox.textchanged)
+    public lazy var textChanged : Event<TypedEventHandler<AutoSuggestBox?, AutoSuggestBoxTextChangedEventArgs?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._default else { return .init() }
+          return try! this.add_TextChangedImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._default.remove_TextChangedImpl($0)
+       }
+      )
+    }()
+
+    internal enum IItemsControlOverrides : ComposableImpl {
+        internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIItemsControlOverrides
+        internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IItemsControlOverrides
+        internal typealias Class = AutoSuggestBox
+        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
+        internal enum Default : AbiInterface {
+            internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBox
+            internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IAutoSuggestBox
+        }
+    }
+    internal typealias Composable = IItemsControlOverrides
+    deinit {
+        _default = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestboxquerysubmittedeventargs)
+public final class AutoSuggestBoxQuerySubmittedEventArgs : WinUI.DependencyObject {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IAutoSuggestBoxQuerySubmittedEventArgs
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxQuerySubmittedEventArgs
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxQuerySubmittedEventArgs>?) -> AutoSuggestBoxQuerySubmittedEventArgs? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    override public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi: fromAbi)
+    }
+
+    override public init() {
+        super.init(fromAbi: try! RoActivateInstance(HString("Microsoft.UI.Xaml.Controls.AutoSuggestBoxQuerySubmittedEventArgs")))
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestboxquerysubmittedeventargs.chosensuggestion)
+    public var chosenSuggestion : Any! {
+        get { try! _default.get_ChosenSuggestionImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestboxquerysubmittedeventargs.querytext)
+    public var queryText : String {
+        get { try! _default.get_QueryTextImpl() }
+    }
+
+    deinit {
+        _default = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestboxsuggestionchoseneventargs)
+public final class AutoSuggestBoxSuggestionChosenEventArgs : WinUI.DependencyObject {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IAutoSuggestBoxSuggestionChosenEventArgs
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxSuggestionChosenEventArgs
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxSuggestionChosenEventArgs>?) -> AutoSuggestBoxSuggestionChosenEventArgs? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    override public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi: fromAbi)
+    }
+
+    override public init() {
+        super.init(fromAbi: try! RoActivateInstance(HString("Microsoft.UI.Xaml.Controls.AutoSuggestBoxSuggestionChosenEventArgs")))
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestboxsuggestionchoseneventargs.selecteditem)
+    public var selectedItem : Any! {
+        get { try! _default.get_SelectedItemImpl() }
+    }
+
+    deinit {
+        _default = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestboxtextchangedeventargs)
+public final class AutoSuggestBoxTextChangedEventArgs : WinUI.DependencyObject {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IAutoSuggestBoxTextChangedEventArgs
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxTextChangedEventArgs
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CIAutoSuggestBoxTextChangedEventArgs>?) -> AutoSuggestBoxTextChangedEventArgs? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    override public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi: fromAbi)
+    }
+
+    override public init() {
+        super.init(fromAbi: try! RoActivateInstance(HString("Microsoft.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs")))
+    }
+
+    private static let _IAutoSuggestBoxTextChangedEventArgsStatics: __ABI_Microsoft_UI_Xaml_Controls.IAutoSuggestBoxTextChangedEventArgsStatics = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestboxtextchangedeventargs.reasonproperty)
+    public static var reasonProperty : WinUI.DependencyProperty! {
+        get { try! _IAutoSuggestBoxTextChangedEventArgsStatics.get_ReasonPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestboxtextchangedeventargs.checkcurrent)
+    public func checkCurrent() throws -> Bool {
+        try _default.CheckCurrentImpl()
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.autosuggestboxtextchangedeventargs.reason)
+    public var reason : AutoSuggestionBoxTextChangeReason {
+        get { try! _default.get_ReasonImpl() }
+        set { try! _default.put_ReasonImpl(newValue) }
+    }
+
+    deinit {
+        _default = nil
     }
 }
 
@@ -5204,6 +5565,178 @@ open class ImageIcon : WinUI.IconElement {
     }
 }
 
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadge)
+open class InfoBadge : WinUI.Control {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IInfoBadge
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadge
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override open func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadge>?) -> InfoBadge? {
+        guard let abi = abi else { return nil }
+        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi: fromAbi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init<Composable: ComposableImpl>(
+        composing: Composable.Type,
+        _ createCallback: (UnsealedWinRTClassWrapper<Composable>?, inout WindowsFoundation.IInspectable?) -> Composable.Default.SwiftABI)
+    {
+        super.init(composing: composing, createCallback)
+    }
+    override open func queryInterface(_ iid: WindowsFoundation.IID) -> IUnknownRef? {
+        return super.queryInterface(iid)
+    }
+    private static var _IInfoBadgeFactory : __ABI_Microsoft_UI_Xaml_Controls.IInfoBadgeFactory =  try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.InfoBadge"))
+
+    override public init() {
+        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+            try! Self._IInfoBadgeFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+        }
+    }
+
+    private static let _IInfoBadgeStatics: __ABI_Microsoft_UI_Xaml_Controls.IInfoBadgeStatics = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.InfoBadge"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadge.iconsourceproperty)
+    public class var iconSourceProperty : WinUI.DependencyProperty! {
+        get { try! _IInfoBadgeStatics.get_IconSourcePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadge.templatesettingsproperty)
+    public class var templateSettingsProperty : WinUI.DependencyProperty! {
+        get { try! _IInfoBadgeStatics.get_TemplateSettingsPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadge.valueproperty)
+    public class var valueProperty : WinUI.DependencyProperty! {
+        get { try! _IInfoBadgeStatics.get_ValuePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadge.iconsource)
+    public var iconSource : IconSource! {
+        get { try! _default.get_IconSourceImpl() }
+        set { try! _default.put_IconSourceImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadge.templatesettings)
+    public var templateSettings : InfoBadgeTemplateSettings! {
+        get { try! _default.get_TemplateSettingsImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadge.value)
+    public var value : Int32 {
+        get { try! _default.get_ValueImpl() }
+        set { try! _default.put_ValueImpl(newValue) }
+    }
+
+    internal enum IControlOverrides : ComposableImpl {
+        internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIControlOverrides
+        internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IControlOverrides
+        internal typealias Class = InfoBadge
+        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
+        internal enum Default : AbiInterface {
+            internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadge
+            internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IInfoBadge
+        }
+    }
+    internal typealias Composable = IControlOverrides
+    deinit {
+        _default = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadgetemplatesettings)
+open class InfoBadgeTemplateSettings : WinUI.DependencyObject {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IInfoBadgeTemplateSettings
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettings
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override open func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettings>?) -> InfoBadgeTemplateSettings? {
+        guard let abi = abi else { return nil }
+        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi: fromAbi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init<Composable: ComposableImpl>(
+        composing: Composable.Type,
+        _ createCallback: (UnsealedWinRTClassWrapper<Composable>?, inout WindowsFoundation.IInspectable?) -> Composable.Default.SwiftABI)
+    {
+        super.init(composing: composing, createCallback)
+    }
+    override open func queryInterface(_ iid: WindowsFoundation.IID) -> IUnknownRef? {
+        return super.queryInterface(iid)
+    }
+    private static var _IInfoBadgeTemplateSettingsFactory : __ABI_Microsoft_UI_Xaml_Controls.IInfoBadgeTemplateSettingsFactory =  try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.InfoBadgeTemplateSettings"))
+
+    override public init() {
+        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+            try! Self._IInfoBadgeTemplateSettingsFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+        }
+    }
+
+    private static let _IInfoBadgeTemplateSettingsStatics: __ABI_Microsoft_UI_Xaml_Controls.IInfoBadgeTemplateSettingsStatics = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.InfoBadgeTemplateSettings"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadgetemplatesettings.iconelementproperty)
+    public class var iconElementProperty : WinUI.DependencyProperty! {
+        get { try! _IInfoBadgeTemplateSettingsStatics.get_IconElementPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadgetemplatesettings.infobadgecornerradiusproperty)
+    public class var infoBadgeCornerRadiusProperty : WinUI.DependencyProperty! {
+        get { try! _IInfoBadgeTemplateSettingsStatics.get_InfoBadgeCornerRadiusPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadgetemplatesettings.iconelement)
+    public var iconElement : IconElement! {
+        get { try! _default.get_IconElementImpl() }
+        set { try! _default.put_IconElementImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobadgetemplatesettings.infobadgecornerradius)
+    public var infoBadgeCornerRadius : WinUI.CornerRadius {
+        get { try! _default.get_InfoBadgeCornerRadiusImpl() }
+        set { try! _default.put_InfoBadgeCornerRadiusImpl(newValue) }
+    }
+
+    internal enum IInfoBadgeTemplateSettings : ComposableImpl {
+        internal typealias CABI = C_IInspectable
+        internal typealias SwiftABI = WindowsFoundation.IInspectable
+        internal typealias Class = InfoBadgeTemplateSettings
+        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
+        internal enum Default : AbiInterface {
+            internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIInfoBadgeTemplateSettings
+            internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IInfoBadgeTemplateSettings
+        }
+    }
+    internal typealias Composable = IInfoBadgeTemplateSettings
+    deinit {
+        _default = nil
+    }
+}
+
 /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.infobar)
 open class InfoBar : WinUI.Control {
     private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IInfoBar
@@ -8981,6 +9514,1292 @@ public final class MenuFlyoutSubItem : WinUI.MenuFlyoutItemBase {
     internal typealias Composable = IControlOverrides
     deinit {
         _default = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview)
+open class NavigationView : WinUI.ContentControl {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationView
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override open func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView>?) -> NavigationView? {
+        guard let abi = abi else { return nil }
+        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi: fromAbi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init<Composable: ComposableImpl>(
+        composing: Composable.Type,
+        _ createCallback: (UnsealedWinRTClassWrapper<Composable>?, inout WindowsFoundation.IInspectable?) -> Composable.Default.SwiftABI)
+    {
+        super.init(composing: composing, createCallback)
+    }
+    override open func queryInterface(_ iid: WindowsFoundation.IID) -> IUnknownRef? {
+        return super.queryInterface(iid)
+    }
+    private static var _INavigationViewFactory : __ABI_Microsoft_UI_Xaml_Controls.INavigationViewFactory =  try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationView"))
+
+    override public init() {
+        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+            try! Self._INavigationViewFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+        }
+    }
+
+    private static let _INavigationViewStatics: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewStatics = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationView"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.alwaysshowheaderproperty)
+    public class var alwaysShowHeaderProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_AlwaysShowHeaderPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.autosuggestboxproperty)
+    public class var autoSuggestBoxProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_AutoSuggestBoxPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.compactmodethresholdwidthproperty)
+    public class var compactModeThresholdWidthProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_CompactModeThresholdWidthPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.compactpanelengthproperty)
+    public class var compactPaneLengthProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_CompactPaneLengthPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.displaymodeproperty)
+    public class var displayModeProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_DisplayModePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.expandedmodethresholdwidthproperty)
+    public class var expandedModeThresholdWidthProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_ExpandedModeThresholdWidthPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.footermenuitemsproperty)
+    public class var footerMenuItemsProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_FooterMenuItemsPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.footermenuitemssourceproperty)
+    public class var footerMenuItemsSourceProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_FooterMenuItemsSourcePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.headerproperty)
+    public class var headerProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_HeaderPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.headertemplateproperty)
+    public class var headerTemplateProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_HeaderTemplatePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.ispaneopenproperty)
+    public class var isPaneOpenProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_IsPaneOpenPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.ispanetogglebuttonvisibleproperty)
+    public class var isPaneToggleButtonVisibleProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_IsPaneToggleButtonVisiblePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.issettingsvisibleproperty)
+    public class var isSettingsVisibleProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_IsSettingsVisiblePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.istitlebarautopaddingenabledproperty)
+    public class var isTitleBarAutoPaddingEnabledProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_IsTitleBarAutoPaddingEnabledPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemcontainerstyleproperty)
+    public class var menuItemContainerStyleProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_MenuItemContainerStylePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemcontainerstyleselectorproperty)
+    public class var menuItemContainerStyleSelectorProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_MenuItemContainerStyleSelectorPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemtemplateproperty)
+    public class var menuItemTemplateProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_MenuItemTemplatePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemtemplateselectorproperty)
+    public class var menuItemTemplateSelectorProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_MenuItemTemplateSelectorPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemsproperty)
+    public class var menuItemsProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_MenuItemsPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemssourceproperty)
+    public class var menuItemsSourceProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_MenuItemsSourcePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.openpanelengthproperty)
+    public class var openPaneLengthProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_OpenPaneLengthPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.panefooterproperty)
+    public class var paneFooterProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_PaneFooterPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.panetogglebuttonstyleproperty)
+    public class var paneToggleButtonStyleProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_PaneToggleButtonStylePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.selecteditemproperty)
+    public class var selectedItemProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_SelectedItemPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.settingsitemproperty)
+    public class var settingsItemProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics.get_SettingsItemPropertyImpl() }
+    }
+
+    private static let _INavigationViewStatics2: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewStatics2 = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationView"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.contentoverlayproperty)
+    public class var contentOverlayProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_ContentOverlayPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.isbackbuttonvisibleproperty)
+    public class var isBackButtonVisibleProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_IsBackButtonVisiblePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.isbackenabledproperty)
+    public class var isBackEnabledProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_IsBackEnabledPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.ispanevisibleproperty)
+    public class var isPaneVisibleProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_IsPaneVisiblePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.overflowlabelmodeproperty)
+    public class var overflowLabelModeProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_OverflowLabelModePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.panecustomcontentproperty)
+    public class var paneCustomContentProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_PaneCustomContentPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.panedisplaymodeproperty)
+    public class var paneDisplayModeProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_PaneDisplayModePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.paneheaderproperty)
+    public class var paneHeaderProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_PaneHeaderPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.panetitleproperty)
+    public class var paneTitleProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_PaneTitlePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.selectionfollowsfocusproperty)
+    public class var selectionFollowsFocusProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_SelectionFollowsFocusPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.shouldernavigationenabledproperty)
+    public class var shoulderNavigationEnabledProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_ShoulderNavigationEnabledPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.templatesettingsproperty)
+    public class var templateSettingsProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewStatics2.get_TemplateSettingsPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemfromcontainer)
+    public func menuItemFromContainer(_ container: WinUI.DependencyObject!) throws -> Any! {
+        try _default.MenuItemFromContainerImpl(container)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.containerfrommenuitem)
+    public func containerFromMenuItem(_ item: Any!) throws -> WinUI.DependencyObject! {
+        try _default.ContainerFromMenuItemImpl(item)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.alwaysshowheader)
+    public var alwaysShowHeader : Bool {
+        get { try! _default.get_AlwaysShowHeaderImpl() }
+        set { try! _default.put_AlwaysShowHeaderImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.autosuggestbox)
+    public var autoSuggestBox : AutoSuggestBox! {
+        get { try! _default.get_AutoSuggestBoxImpl() }
+        set { try! _default.put_AutoSuggestBoxImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.compactmodethresholdwidth)
+    public var compactModeThresholdWidth : Double {
+        get { try! _default.get_CompactModeThresholdWidthImpl() }
+        set { try! _default.put_CompactModeThresholdWidthImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.compactpanelength)
+    public var compactPaneLength : Double {
+        get { try! _default.get_CompactPaneLengthImpl() }
+        set { try! _default.put_CompactPaneLengthImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.displaymode)
+    public var displayMode : NavigationViewDisplayMode {
+        get { try! _default.get_DisplayModeImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.expandedmodethresholdwidth)
+    public var expandedModeThresholdWidth : Double {
+        get { try! _default.get_ExpandedModeThresholdWidthImpl() }
+        set { try! _default.put_ExpandedModeThresholdWidthImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.footermenuitems)
+    public var footerMenuItems : WindowsFoundation.AnyIVector<Any?>! {
+        get { try! _default.get_FooterMenuItemsImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.footermenuitemssource)
+    public var footerMenuItemsSource : Any! {
+        get { try! _default.get_FooterMenuItemsSourceImpl() }
+        set { try! _default.put_FooterMenuItemsSourceImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.header)
+    public var header : Any! {
+        get { try! _default.get_HeaderImpl() }
+        set { try! _default.put_HeaderImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.headertemplate)
+    public var headerTemplate : WinUI.DataTemplate! {
+        get { try! _default.get_HeaderTemplateImpl() }
+        set { try! _default.put_HeaderTemplateImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.ispaneopen)
+    public var isPaneOpen : Bool {
+        get { try! _default.get_IsPaneOpenImpl() }
+        set { try! _default.put_IsPaneOpenImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.ispanetogglebuttonvisible)
+    public var isPaneToggleButtonVisible : Bool {
+        get { try! _default.get_IsPaneToggleButtonVisibleImpl() }
+        set { try! _default.put_IsPaneToggleButtonVisibleImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.issettingsvisible)
+    public var isSettingsVisible : Bool {
+        get { try! _default.get_IsSettingsVisibleImpl() }
+        set { try! _default.put_IsSettingsVisibleImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.istitlebarautopaddingenabled)
+    public var isTitleBarAutoPaddingEnabled : Bool {
+        get { try! _default.get_IsTitleBarAutoPaddingEnabledImpl() }
+        set { try! _default.put_IsTitleBarAutoPaddingEnabledImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemcontainerstyle)
+    public var menuItemContainerStyle : WinUI.Style! {
+        get { try! _default.get_MenuItemContainerStyleImpl() }
+        set { try! _default.put_MenuItemContainerStyleImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemcontainerstyleselector)
+    public var menuItemContainerStyleSelector : StyleSelector! {
+        get { try! _default.get_MenuItemContainerStyleSelectorImpl() }
+        set { try! _default.put_MenuItemContainerStyleSelectorImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemtemplate)
+    public var menuItemTemplate : WinUI.DataTemplate! {
+        get { try! _default.get_MenuItemTemplateImpl() }
+        set { try! _default.put_MenuItemTemplateImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemtemplateselector)
+    public var menuItemTemplateSelector : DataTemplateSelector! {
+        get { try! _default.get_MenuItemTemplateSelectorImpl() }
+        set { try! _default.put_MenuItemTemplateSelectorImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitems)
+    public var menuItems : WindowsFoundation.AnyIVector<Any?>! {
+        get { try! _default.get_MenuItemsImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.menuitemssource)
+    public var menuItemsSource : Any! {
+        get { try! _default.get_MenuItemsSourceImpl() }
+        set { try! _default.put_MenuItemsSourceImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.openpanelength)
+    public var openPaneLength : Double {
+        get { try! _default.get_OpenPaneLengthImpl() }
+        set { try! _default.put_OpenPaneLengthImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.panefooter)
+    public var paneFooter : WinUI.UIElement! {
+        get { try! _default.get_PaneFooterImpl() }
+        set { try! _default.put_PaneFooterImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.panetogglebuttonstyle)
+    public var paneToggleButtonStyle : WinUI.Style! {
+        get { try! _default.get_PaneToggleButtonStyleImpl() }
+        set { try! _default.put_PaneToggleButtonStyleImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.selecteditem)
+    public var selectedItem : Any! {
+        get { try! _default.get_SelectedItemImpl() }
+        set { try! _default.put_SelectedItemImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.settingsitem)
+    public var settingsItem : Any! {
+        get { try! _default.get_SettingsItemImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.displaymodechanged)
+    public lazy var displayModeChanged : Event<TypedEventHandler<NavigationView?, NavigationViewDisplayModeChangedEventArgs?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._default else { return .init() }
+          return try! this.add_DisplayModeChangedImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._default.remove_DisplayModeChangedImpl($0)
+       }
+      )
+    }()
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.iteminvoked)
+    public lazy var itemInvoked : Event<TypedEventHandler<NavigationView?, NavigationViewItemInvokedEventArgs?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._default else { return .init() }
+          return try! this.add_ItemInvokedImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._default.remove_ItemInvokedImpl($0)
+       }
+      )
+    }()
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.selectionchanged)
+    public lazy var selectionChanged : Event<TypedEventHandler<NavigationView?, NavigationViewSelectionChangedEventArgs?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._default else { return .init() }
+          return try! this.add_SelectionChangedImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._default.remove_SelectionChangedImpl($0)
+       }
+      )
+    }()
+
+    private lazy var _INavigationView2: __ABI_Microsoft_UI_Xaml_Controls.INavigationView2! = getInterfaceForCaching()
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.expand)
+    public func expand(_ item: NavigationViewItem!) throws {
+        try _INavigationView2.ExpandImpl(item)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.collapse)
+    public func collapse(_ item: NavigationViewItem!) throws {
+        try _INavigationView2.CollapseImpl(item)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.contentoverlay)
+    public var contentOverlay : WinUI.UIElement! {
+        get { try! _INavigationView2.get_ContentOverlayImpl() }
+        set { try! _INavigationView2.put_ContentOverlayImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.isbackbuttonvisible)
+    public var isBackButtonVisible : NavigationViewBackButtonVisible {
+        get { try! _INavigationView2.get_IsBackButtonVisibleImpl() }
+        set { try! _INavigationView2.put_IsBackButtonVisibleImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.isbackenabled)
+    public var isBackEnabled : Bool {
+        get { try! _INavigationView2.get_IsBackEnabledImpl() }
+        set { try! _INavigationView2.put_IsBackEnabledImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.ispanevisible)
+    public var isPaneVisible : Bool {
+        get { try! _INavigationView2.get_IsPaneVisibleImpl() }
+        set { try! _INavigationView2.put_IsPaneVisibleImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.overflowlabelmode)
+    public var overflowLabelMode : NavigationViewOverflowLabelMode {
+        get { try! _INavigationView2.get_OverflowLabelModeImpl() }
+        set { try! _INavigationView2.put_OverflowLabelModeImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.panecustomcontent)
+    public var paneCustomContent : WinUI.UIElement! {
+        get { try! _INavigationView2.get_PaneCustomContentImpl() }
+        set { try! _INavigationView2.put_PaneCustomContentImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.panedisplaymode)
+    public var paneDisplayMode : NavigationViewPaneDisplayMode {
+        get { try! _INavigationView2.get_PaneDisplayModeImpl() }
+        set { try! _INavigationView2.put_PaneDisplayModeImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.paneheader)
+    public var paneHeader : WinUI.UIElement! {
+        get { try! _INavigationView2.get_PaneHeaderImpl() }
+        set { try! _INavigationView2.put_PaneHeaderImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.panetitle)
+    public var paneTitle : String {
+        get { try! _INavigationView2.get_PaneTitleImpl() }
+        set { try! _INavigationView2.put_PaneTitleImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.selectionfollowsfocus)
+    public var selectionFollowsFocus : NavigationViewSelectionFollowsFocus {
+        get { try! _INavigationView2.get_SelectionFollowsFocusImpl() }
+        set { try! _INavigationView2.put_SelectionFollowsFocusImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.shouldernavigationenabled)
+    public var shoulderNavigationEnabled : NavigationViewShoulderNavigationEnabled {
+        get { try! _INavigationView2.get_ShoulderNavigationEnabledImpl() }
+        set { try! _INavigationView2.put_ShoulderNavigationEnabledImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.templatesettings)
+    public var templateSettings : NavigationViewTemplateSettings! {
+        get { try! _INavigationView2.get_TemplateSettingsImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.backrequested)
+    public lazy var backRequested : Event<TypedEventHandler<NavigationView?, NavigationViewBackRequestedEventArgs?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._INavigationView2 else { return .init() }
+          return try! this.add_BackRequestedImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._INavigationView2.remove_BackRequestedImpl($0)
+       }
+      )
+    }()
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.collapsed)
+    public lazy var collapsed : Event<TypedEventHandler<NavigationView?, NavigationViewItemCollapsedEventArgs?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._INavigationView2 else { return .init() }
+          return try! this.add_CollapsedImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._INavigationView2.remove_CollapsedImpl($0)
+       }
+      )
+    }()
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.expanding)
+    public lazy var expanding : Event<TypedEventHandler<NavigationView?, NavigationViewItemExpandingEventArgs?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._INavigationView2 else { return .init() }
+          return try! this.add_ExpandingImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._INavigationView2.remove_ExpandingImpl($0)
+       }
+      )
+    }()
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.paneclosed)
+    public lazy var paneClosed : Event<TypedEventHandler<NavigationView?, Any?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._INavigationView2 else { return .init() }
+          return try! this.add_PaneClosedImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._INavigationView2.remove_PaneClosedImpl($0)
+       }
+      )
+    }()
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.paneclosing)
+    public lazy var paneClosing : Event<TypedEventHandler<NavigationView?, NavigationViewPaneClosingEventArgs?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._INavigationView2 else { return .init() }
+          return try! this.add_PaneClosingImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._INavigationView2.remove_PaneClosingImpl($0)
+       }
+      )
+    }()
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.paneopened)
+    public lazy var paneOpened : Event<TypedEventHandler<NavigationView?, Any?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._INavigationView2 else { return .init() }
+          return try! this.add_PaneOpenedImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._INavigationView2.remove_PaneOpenedImpl($0)
+       }
+      )
+    }()
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationview.paneopening)
+    public lazy var paneOpening : Event<TypedEventHandler<NavigationView?, Any?>> = {
+      .init(
+        add: { [weak self] in
+          guard let this = self?._INavigationView2 else { return .init() }
+          return try! this.add_PaneOpeningImpl($0)
+        },
+        remove: { [weak self] in
+         try? self?._INavigationView2.remove_PaneOpeningImpl($0)
+       }
+      )
+    }()
+
+    internal enum IContentControlOverrides : ComposableImpl {
+        internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIContentControlOverrides
+        internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IContentControlOverrides
+        internal typealias Class = NavigationView
+        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
+        internal enum Default : AbiInterface {
+            internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationView
+            internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationView
+        }
+    }
+    internal typealias Composable = IContentControlOverrides
+    deinit {
+        _default = nil
+        _INavigationView2 = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewbackrequestedeventargs)
+public final class NavigationViewBackRequestedEventArgs : WinRTClass {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewBackRequestedEventArgs
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewBackRequestedEventArgs
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewBackRequestedEventArgs>?) -> NavigationViewBackRequestedEventArgs? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi)
+    }
+
+    deinit {
+        _default = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewdisplaymodechangedeventargs)
+public final class NavigationViewDisplayModeChangedEventArgs : WinRTClass {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewDisplayModeChangedEventArgs
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewDisplayModeChangedEventArgs
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewDisplayModeChangedEventArgs>?) -> NavigationViewDisplayModeChangedEventArgs? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewdisplaymodechangedeventargs.displaymode)
+    public var displayMode : NavigationViewDisplayMode {
+        get { try! _default.get_DisplayModeImpl() }
+    }
+
+    deinit {
+        _default = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem)
+open class NavigationViewItem : WinUI.NavigationViewItemBase {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItem
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override open func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem>?) -> NavigationViewItem? {
+        guard let abi = abi else { return nil }
+        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi: fromAbi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init<Composable: ComposableImpl>(
+        composing: Composable.Type,
+        _ createCallback: (UnsealedWinRTClassWrapper<Composable>?, inout WindowsFoundation.IInspectable?) -> Composable.Default.SwiftABI)
+    {
+        super.init(composing: composing, createCallback)
+    }
+    override open func queryInterface(_ iid: WindowsFoundation.IID) -> IUnknownRef? {
+        return super.queryInterface(iid)
+    }
+    private static var _INavigationViewItemFactory : __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemFactory =  try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationViewItem"))
+
+    public init() {
+        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+            try! Self._INavigationViewItemFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+        }
+    }
+
+    private static let _INavigationViewItemStatics: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemStatics = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationViewItem"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.compactpanelengthproperty)
+    public class var compactPaneLengthProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewItemStatics.get_CompactPaneLengthPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.iconproperty)
+    public class var iconProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewItemStatics.get_IconPropertyImpl() }
+    }
+
+    private static let _INavigationViewItemStatics2: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemStatics2 = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationViewItem"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.hasunrealizedchildrenproperty)
+    public class var hasUnrealizedChildrenProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewItemStatics2.get_HasUnrealizedChildrenPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.ischildselectedproperty)
+    public class var isChildSelectedProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewItemStatics2.get_IsChildSelectedPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.isexpandedproperty)
+    public class var isExpandedProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewItemStatics2.get_IsExpandedPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.menuitemsproperty)
+    public class var menuItemsProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewItemStatics2.get_MenuItemsPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.menuitemssourceproperty)
+    public class var menuItemsSourceProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewItemStatics2.get_MenuItemsSourcePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.selectsoninvokedproperty)
+    public class var selectsOnInvokedProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewItemStatics2.get_SelectsOnInvokedPropertyImpl() }
+    }
+
+    private static let _INavigationViewItemStatics3: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemStatics3 = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationViewItem"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.infobadgeproperty)
+    public class var infoBadgeProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewItemStatics3.get_InfoBadgePropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.compactpanelength)
+    public var compactPaneLength : Double {
+        get { try! _default.get_CompactPaneLengthImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.icon)
+    public var icon : IconElement! {
+        get { try! _default.get_IconImpl() }
+        set { try! _default.put_IconImpl(newValue) }
+    }
+
+    private lazy var _INavigationViewItem2: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItem2! = getInterfaceForCaching()
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.hasunrealizedchildren)
+    public var hasUnrealizedChildren : Bool {
+        get { try! _INavigationViewItem2.get_HasUnrealizedChildrenImpl() }
+        set { try! _INavigationViewItem2.put_HasUnrealizedChildrenImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.ischildselected)
+    public var isChildSelected : Bool {
+        get { try! _INavigationViewItem2.get_IsChildSelectedImpl() }
+        set { try! _INavigationViewItem2.put_IsChildSelectedImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.isexpanded)
+    public var isExpanded : Bool {
+        get { try! _INavigationViewItem2.get_IsExpandedImpl() }
+        set { try! _INavigationViewItem2.put_IsExpandedImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.menuitems)
+    public var menuItems : WindowsFoundation.AnyIVector<Any?>! {
+        get { try! _INavigationViewItem2.get_MenuItemsImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.menuitemssource)
+    public var menuItemsSource : Any! {
+        get { try! _INavigationViewItem2.get_MenuItemsSourceImpl() }
+        set { try! _INavigationViewItem2.put_MenuItemsSourceImpl(newValue) }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.selectsoninvoked)
+    public var selectsOnInvoked : Bool {
+        get { try! _INavigationViewItem2.get_SelectsOnInvokedImpl() }
+        set { try! _INavigationViewItem2.put_SelectsOnInvokedImpl(newValue) }
+    }
+
+    private lazy var _INavigationViewItem3: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItem3! = getInterfaceForCaching()
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitem.infobadge)
+    public var infoBadge : InfoBadge! {
+        get { try! _INavigationViewItem3.get_InfoBadgeImpl() }
+        set { try! _INavigationViewItem3.put_InfoBadgeImpl(newValue) }
+    }
+
+    internal enum IContentControlOverrides : ComposableImpl {
+        internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIContentControlOverrides
+        internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IContentControlOverrides
+        internal typealias Class = NavigationViewItem
+        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
+        internal enum Default : AbiInterface {
+            internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItem
+            internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItem
+        }
+    }
+    internal typealias Composable = IContentControlOverrides
+    deinit {
+        _default = nil
+        _INavigationViewItem2 = nil
+        _INavigationViewItem3 = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitembase)
+open class NavigationViewItemBase : WinUI.ContentControl {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemBase
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBase
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override open func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBase>?) -> NavigationViewItemBase? {
+        guard let abi = abi else { return nil }
+        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi: fromAbi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init<Composable: ComposableImpl>(
+        composing: Composable.Type,
+        _ createCallback: (UnsealedWinRTClassWrapper<Composable>?, inout WindowsFoundation.IInspectable?) -> Composable.Default.SwiftABI)
+    {
+        super.init(composing: composing, createCallback)
+    }
+    override open func queryInterface(_ iid: WindowsFoundation.IID) -> IUnknownRef? {
+        return super.queryInterface(iid)
+    }
+    private static var _INavigationViewItemBaseFactory : __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemBaseFactory =  try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationViewItemBase"))
+
+    private static let _INavigationViewItemBaseStatics: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemBaseStatics = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationViewItemBase"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitembase.isselectedproperty)
+    public class var isSelectedProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewItemBaseStatics.get_IsSelectedPropertyImpl() }
+    }
+
+    private lazy var _INavigationViewItemBase2: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemBase2! = getInterfaceForCaching()
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitembase.isselected)
+    public var isSelected : Bool {
+        get { try! _INavigationViewItemBase2.get_IsSelectedImpl() }
+        set { try! _INavigationViewItemBase2.put_IsSelectedImpl(newValue) }
+    }
+
+    internal enum IContentControlOverrides : ComposableImpl {
+        internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CIContentControlOverrides
+        internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.IContentControlOverrides
+        internal typealias Class = NavigationViewItemBase
+        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
+        internal enum Default : AbiInterface {
+            internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemBase
+            internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemBase
+        }
+    }
+    internal typealias Composable = IContentControlOverrides
+    deinit {
+        _default = nil
+        _INavigationViewItemBase2 = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitemcollapsedeventargs)
+public final class NavigationViewItemCollapsedEventArgs : WinRTClass {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemCollapsedEventArgs
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemCollapsedEventArgs
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemCollapsedEventArgs>?) -> NavigationViewItemCollapsedEventArgs? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitemcollapsedeventargs.collapseditem)
+    public var collapsedItem : Any! {
+        get { try! _default.get_CollapsedItemImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitemcollapsedeventargs.collapseditemcontainer)
+    public var collapsedItemContainer : NavigationViewItemBase! {
+        get { try! _default.get_CollapsedItemContainerImpl() }
+    }
+
+    deinit {
+        _default = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitemexpandingeventargs)
+public final class NavigationViewItemExpandingEventArgs : WinRTClass {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemExpandingEventArgs
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemExpandingEventArgs
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemExpandingEventArgs>?) -> NavigationViewItemExpandingEventArgs? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitemexpandingeventargs.expandingitem)
+    public var expandingItem : Any! {
+        get { try! _default.get_ExpandingItemImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewitemexpandingeventargs.expandingitemcontainer)
+    public var expandingItemContainer : NavigationViewItemBase! {
+        get { try! _default.get_ExpandingItemContainerImpl() }
+    }
+
+    deinit {
+        _default = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewiteminvokedeventargs)
+public final class NavigationViewItemInvokedEventArgs : WinRTClass {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemInvokedEventArgs
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemInvokedEventArgs
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewItemInvokedEventArgs>?) -> NavigationViewItemInvokedEventArgs? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi)
+    }
+
+    override public init() {
+        super.init(try! RoActivateInstance(HString("Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs")))
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewiteminvokedeventargs.invokeditem)
+    public var invokedItem : Any! {
+        get { try! _default.get_InvokedItemImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewiteminvokedeventargs.issettingsinvoked)
+    public var isSettingsInvoked : Bool {
+        get { try! _default.get_IsSettingsInvokedImpl() }
+    }
+
+    private lazy var _INavigationViewItemInvokedEventArgs2: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewItemInvokedEventArgs2! = getInterfaceForCaching()
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewiteminvokedeventargs.invokeditemcontainer)
+    public var invokedItemContainer : NavigationViewItemBase! {
+        get { try! _INavigationViewItemInvokedEventArgs2.get_InvokedItemContainerImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewiteminvokedeventargs.recommendednavigationtransitioninfo)
+    public var recommendedNavigationTransitionInfo : WinUI.NavigationTransitionInfo! {
+        get { try! _INavigationViewItemInvokedEventArgs2.get_RecommendedNavigationTransitionInfoImpl() }
+    }
+
+    deinit {
+        _default = nil
+        _INavigationViewItemInvokedEventArgs2 = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewpaneclosingeventargs)
+public final class NavigationViewPaneClosingEventArgs : WinRTClass {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewPaneClosingEventArgs
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewPaneClosingEventArgs
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewPaneClosingEventArgs>?) -> NavigationViewPaneClosingEventArgs? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewpaneclosingeventargs.cancel)
+    public var cancel : Bool {
+        get { try! _default.get_CancelImpl() }
+        set { try! _default.put_CancelImpl(newValue) }
+    }
+
+    deinit {
+        _default = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewselectionchangedeventargs)
+public final class NavigationViewSelectionChangedEventArgs : WinRTClass {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewSelectionChangedEventArgs
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewSelectionChangedEventArgs
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewSelectionChangedEventArgs>?) -> NavigationViewSelectionChangedEventArgs? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: WindowsFoundation.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewselectionchangedeventargs.issettingsselected)
+    public var isSettingsSelected : Bool {
+        get { try! _default.get_IsSettingsSelectedImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewselectionchangedeventargs.selecteditem)
+    public var selectedItem : Any! {
+        get { try! _default.get_SelectedItemImpl() }
+    }
+
+    private lazy var _INavigationViewSelectionChangedEventArgs2: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewSelectionChangedEventArgs2! = getInterfaceForCaching()
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewselectionchangedeventargs.recommendednavigationtransitioninfo)
+    public var recommendedNavigationTransitionInfo : WinUI.NavigationTransitionInfo! {
+        get { try! _INavigationViewSelectionChangedEventArgs2.get_RecommendedNavigationTransitionInfoImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewselectionchangedeventargs.selecteditemcontainer)
+    public var selectedItemContainer : NavigationViewItemBase! {
+        get { try! _INavigationViewSelectionChangedEventArgs2.get_SelectedItemContainerImpl() }
+    }
+
+    deinit {
+        _default = nil
+        _INavigationViewSelectionChangedEventArgs2 = nil
+    }
+}
+
+/// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings)
+open class NavigationViewTemplateSettings : WinUI.DependencyObject {
+    private typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewTemplateSettings
+    private typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override open func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings>?) -> NavigationViewTemplateSettings? {
+        guard let abi = abi else { return nil }
+        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init(fromAbi: WindowsFoundation.IInspectable) {
+        super.init(fromAbi: fromAbi)
+    }
+
+    @_spi(WinRTInternal)
+    override public init<Composable: ComposableImpl>(
+        composing: Composable.Type,
+        _ createCallback: (UnsealedWinRTClassWrapper<Composable>?, inout WindowsFoundation.IInspectable?) -> Composable.Default.SwiftABI)
+    {
+        super.init(composing: composing, createCallback)
+    }
+    override open func queryInterface(_ iid: WindowsFoundation.IID) -> IUnknownRef? {
+        return super.queryInterface(iid)
+    }
+    private static var _INavigationViewTemplateSettingsFactory : __ABI_Microsoft_UI_Xaml_Controls.INavigationViewTemplateSettingsFactory =  try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationViewTemplateSettings"))
+
+    override public init() {
+        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+            try! Self._INavigationViewTemplateSettingsFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+        }
+    }
+
+    private static let _INavigationViewTemplateSettingsStatics: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewTemplateSettingsStatics = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationViewTemplateSettings"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.backbuttonvisibilityproperty)
+    public class var backButtonVisibilityProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewTemplateSettingsStatics.get_BackButtonVisibilityPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.leftpanevisibilityproperty)
+    public class var leftPaneVisibilityProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewTemplateSettingsStatics.get_LeftPaneVisibilityPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.overflowbuttonvisibilityproperty)
+    public class var overflowButtonVisibilityProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewTemplateSettingsStatics.get_OverflowButtonVisibilityPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.panetogglebuttonvisibilityproperty)
+    public class var paneToggleButtonVisibilityProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewTemplateSettingsStatics.get_PaneToggleButtonVisibilityPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.panetogglebuttonwidthproperty)
+    public class var paneToggleButtonWidthProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewTemplateSettingsStatics.get_PaneToggleButtonWidthPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.singleselectionfollowsfocusproperty)
+    public class var singleSelectionFollowsFocusProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewTemplateSettingsStatics.get_SingleSelectionFollowsFocusPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.smallerpanetogglebuttonwidthproperty)
+    public class var smallerPaneToggleButtonWidthProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewTemplateSettingsStatics.get_SmallerPaneToggleButtonWidthPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.toppaddingproperty)
+    public class var topPaddingProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewTemplateSettingsStatics.get_TopPaddingPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.toppanevisibilityproperty)
+    public class var topPaneVisibilityProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewTemplateSettingsStatics.get_TopPaneVisibilityPropertyImpl() }
+    }
+
+    private static let _INavigationViewTemplateSettingsStatics2: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewTemplateSettingsStatics2 = try! RoGetActivationFactory(HString("Microsoft.UI.Xaml.Controls.NavigationViewTemplateSettings"))
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.openpanelengthproperty)
+    public class var openPaneLengthProperty : WinUI.DependencyProperty! {
+        get { try! _INavigationViewTemplateSettingsStatics2.get_OpenPaneLengthPropertyImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.backbuttonvisibility)
+    public var backButtonVisibility : WinUI.Visibility {
+        get { try! _default.get_BackButtonVisibilityImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.leftpanevisibility)
+    public var leftPaneVisibility : WinUI.Visibility {
+        get { try! _default.get_LeftPaneVisibilityImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.overflowbuttonvisibility)
+    public var overflowButtonVisibility : WinUI.Visibility {
+        get { try! _default.get_OverflowButtonVisibilityImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.panetogglebuttonvisibility)
+    public var paneToggleButtonVisibility : WinUI.Visibility {
+        get { try! _default.get_PaneToggleButtonVisibilityImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.panetogglebuttonwidth)
+    public var paneToggleButtonWidth : Double {
+        get { try! _default.get_PaneToggleButtonWidthImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.singleselectionfollowsfocus)
+    public var singleSelectionFollowsFocus : Bool {
+        get { try! _default.get_SingleSelectionFollowsFocusImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.smallerpanetogglebuttonwidth)
+    public var smallerPaneToggleButtonWidth : Double {
+        get { try! _default.get_SmallerPaneToggleButtonWidthImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.toppadding)
+    public var topPadding : Double {
+        get { try! _default.get_TopPaddingImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.toppanevisibility)
+    public var topPaneVisibility : WinUI.Visibility {
+        get { try! _default.get_TopPaneVisibilityImpl() }
+    }
+
+    private lazy var _INavigationViewTemplateSettings2: __ABI_Microsoft_UI_Xaml_Controls.INavigationViewTemplateSettings2! = getInterfaceForCaching()
+    /// [Open Microsoft documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.navigationviewtemplatesettings.openpanelength)
+    public var openPaneLength : Double {
+        get { try! _INavigationViewTemplateSettings2.get_OpenPaneLengthImpl() }
+    }
+
+    internal enum INavigationViewTemplateSettings : ComposableImpl {
+        internal typealias CABI = C_IInspectable
+        internal typealias SwiftABI = WindowsFoundation.IInspectable
+        internal typealias Class = NavigationViewTemplateSettings
+        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
+        internal enum Default : AbiInterface {
+            internal typealias CABI = __x_ABI_CMicrosoft_CUI_CXaml_CControls_CINavigationViewTemplateSettings
+            internal typealias SwiftABI = __ABI_Microsoft_UI_Xaml_Controls.INavigationViewTemplateSettings
+        }
+    }
+    internal typealias Composable = INavigationViewTemplateSettings
+    deinit {
+        _default = nil
+        _INavigationViewTemplateSettings2 = nil
     }
 }
 
@@ -18056,6 +19875,19 @@ extension WinUI.AppBarClosedDisplayMode {
 }
 extension WinUI.AppBarClosedDisplayMode: @retroactive Hashable, @retroactive Codable {}
 
+extension WinUI.AutoSuggestionBoxTextChangeReason {
+    public static var userInput : WinUI.AutoSuggestionBoxTextChangeReason {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CAutoSuggestionBoxTextChangeReason_UserInput
+    }
+    public static var programmaticChange : WinUI.AutoSuggestionBoxTextChangeReason {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CAutoSuggestionBoxTextChangeReason_ProgrammaticChange
+    }
+    public static var suggestionChosen : WinUI.AutoSuggestionBoxTextChangeReason {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CAutoSuggestionBoxTextChangeReason_SuggestionChosen
+    }
+}
+extension WinUI.AutoSuggestionBoxTextChangeReason: @retroactive Hashable, @retroactive Codable {}
+
 extension WinUI.BackgroundSizing {
     public static var innerBorderEdge : WinUI.BackgroundSizing {
         __x_ABI_CMicrosoft_CUI_CXaml_CControls_CBackgroundSizing_InnerBorderEdge
@@ -18280,6 +20112,84 @@ extension WinUI.ListViewSelectionMode {
     }
 }
 extension WinUI.ListViewSelectionMode: @retroactive Hashable, @retroactive Codable {}
+
+extension WinUI.NavigationViewBackButtonVisible {
+    public static var collapsed : WinUI.NavigationViewBackButtonVisible {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewBackButtonVisible_Collapsed
+    }
+    public static var visible : WinUI.NavigationViewBackButtonVisible {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewBackButtonVisible_Visible
+    }
+    public static var auto : WinUI.NavigationViewBackButtonVisible {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewBackButtonVisible_Auto
+    }
+}
+extension WinUI.NavigationViewBackButtonVisible: @retroactive Hashable, @retroactive Codable {}
+
+extension WinUI.NavigationViewDisplayMode {
+    public static var minimal : WinUI.NavigationViewDisplayMode {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewDisplayMode_Minimal
+    }
+    public static var compact : WinUI.NavigationViewDisplayMode {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewDisplayMode_Compact
+    }
+    public static var expanded : WinUI.NavigationViewDisplayMode {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewDisplayMode_Expanded
+    }
+}
+extension WinUI.NavigationViewDisplayMode: @retroactive Hashable, @retroactive Codable {}
+
+extension WinUI.NavigationViewOverflowLabelMode {
+    public static var moreLabel : WinUI.NavigationViewOverflowLabelMode {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewOverflowLabelMode_MoreLabel
+    }
+    public static var noLabel : WinUI.NavigationViewOverflowLabelMode {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewOverflowLabelMode_NoLabel
+    }
+}
+extension WinUI.NavigationViewOverflowLabelMode: @retroactive Hashable, @retroactive Codable {}
+
+extension WinUI.NavigationViewPaneDisplayMode {
+    public static var auto : WinUI.NavigationViewPaneDisplayMode {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewPaneDisplayMode_Auto
+    }
+    public static var left : WinUI.NavigationViewPaneDisplayMode {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewPaneDisplayMode_Left
+    }
+    public static var top : WinUI.NavigationViewPaneDisplayMode {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewPaneDisplayMode_Top
+    }
+    public static var leftCompact : WinUI.NavigationViewPaneDisplayMode {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewPaneDisplayMode_LeftCompact
+    }
+    public static var leftMinimal : WinUI.NavigationViewPaneDisplayMode {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewPaneDisplayMode_LeftMinimal
+    }
+}
+extension WinUI.NavigationViewPaneDisplayMode: @retroactive Hashable, @retroactive Codable {}
+
+extension WinUI.NavigationViewSelectionFollowsFocus {
+    public static var disabled : WinUI.NavigationViewSelectionFollowsFocus {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewSelectionFollowsFocus_Disabled
+    }
+    public static var enabled : WinUI.NavigationViewSelectionFollowsFocus {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewSelectionFollowsFocus_Enabled
+    }
+}
+extension WinUI.NavigationViewSelectionFollowsFocus: @retroactive Hashable, @retroactive Codable {}
+
+extension WinUI.NavigationViewShoulderNavigationEnabled {
+    public static var whenSelectionFollowsFocus : WinUI.NavigationViewShoulderNavigationEnabled {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewShoulderNavigationEnabled_WhenSelectionFollowsFocus
+    }
+    public static var always : WinUI.NavigationViewShoulderNavigationEnabled {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewShoulderNavigationEnabled_Always
+    }
+    public static var never : WinUI.NavigationViewShoulderNavigationEnabled {
+        __x_ABI_CMicrosoft_CUI_CXaml_CControls_CNavigationViewShoulderNavigationEnabled_Never
+    }
+}
+extension WinUI.NavigationViewShoulderNavigationEnabled: @retroactive Hashable, @retroactive Codable {}
 
 extension WinUI.Orientation {
     public static var vertical : WinUI.Orientation {

--- a/Sources/WinUI/Generated/WinUI+Generics.swift
+++ b/Sources/WinUI/Generated/WinUI+Generics.swift
@@ -30282,7 +30282,7 @@ internal var __x_ABI_C__FIAsyncOperation_1_IInspectableVTable: __x_ABI_C__FIAsyn
             let resultWrapper = __ABI_.AnyWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) }
+        } catch { return failWith(err: E_FAIL) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_IInspectableWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FIAsyncOperation_1_IInspectableBridge>
@@ -30435,7 +30435,7 @@ internal var __x_ABI_C__FIAsyncOperation_1_booleanVTable: __x_ABI_C__FIAsyncOper
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: .init(from: result))
             return S_OK
-        } catch { return failWith(err: E_FAIL) }
+        } catch { return failWith(err: E_FAIL) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_booleanWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FIAsyncOperation_1_booleanBridge>
@@ -30587,7 +30587,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CCont
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: result)
             return S_OK
-        } catch { return failWith(err: E_FAIL) }
+        } catch { return failWith(err: E_FAIL) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CControls__CContentDialogResultWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CControls__CContentDialogResultBridge>
@@ -30739,7 +30739,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CData
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: .from(swift: result))
             return S_OK
-        } catch { return failWith(err: E_FAIL) }
+        } catch { return failWith(err: E_FAIL) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CData__CLoadMoreItemsResultWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CData__CLoadMoreItemsResultBridge>
@@ -30891,7 +30891,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CInpu
             let result = try __unwrapped__instance.getResults()
             result?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) }
+        } catch { return failWith(err: E_FAIL) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CInput__CFocusMovementResultWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CInput__CFocusMovementResultBridge>
@@ -31044,7 +31044,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CMedi
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: result)
             return S_OK
-        } catch { return failWith(err: E_FAIL) }
+        } catch { return failWith(err: E_FAIL) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CMedia__CImaging__CSvgImageSourceLoadStatusWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FIAsyncOperation_1___x_ABI_CMicrosoft__CUI__CXaml__CMedia__CImaging__CSvgImageSourceLoadStatusBridge>
@@ -31196,7 +31196,7 @@ internal var __x_ABI_C__FIAsyncOperation_1_HSTRINGVTable: __x_ABI_C__FIAsyncOper
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: try! HString(result).detach())
             return S_OK
-        } catch { return failWith(err: E_FAIL) }
+        } catch { return failWith(err: E_FAIL) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_HSTRINGWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FIAsyncOperation_1_HSTRINGBridge>
@@ -31348,7 +31348,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CApplicationModel__
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: result)
             return S_OK
-        } catch { return failWith(err: E_FAIL) }
+        } catch { return failWith(err: E_FAIL) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CApplicationModel__CDataTransfer__CDataPackageOperationWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CApplicationModel__CDataTransfer__CDataPackageOperationBridge>
@@ -31501,7 +31501,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1_HSTRINGVTab
             let resultWrapper = WinUI.__x_ABI_C__FIVectorView_1_HSTRINGWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) }
+        } catch { return failWith(err: E_FAIL) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1_HSTRINGWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1_HSTRINGBridge>
@@ -31655,7 +31655,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams_
             let resultWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) }
+        } catch { return failWith(err: E_FAIL) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferBridge>
@@ -32579,6 +32579,153 @@ internal class __x_ABI_C__FITypedEventHandler_2_IInspectable___x_ABI_CMicrosoft_
     internal typealias Handler = WindowsFoundation.TypedEventHandler<Any?, WinUI.WindowVisibilityChangedEventArgs?>
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2_IInspectable___x_ABI_CMicrosoft__CUI__CXaml__CWindowVisibilityChangedEventArgs
     internal typealias SwiftABI = WinUI.TypedEventHandlerAny_WindowVisibilityChangedEventArgs
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x81a5bbfb, Data2: 0x8f64, Data3: 0x5c79, Data4: ( 0x84,0x8b,0xd5,0x9d,0x19,0x81,0x53,0xa8 ))// 81a5bbfb-8f64-5c79-848b-d59d198153a8
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgs {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.AutoSuggestBox? = .from(abi: ComPtr($1))
+        let args: WinUI.AutoSuggestBoxQuerySubmittedEventArgs? = .from(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsBridge>
+internal class TypedEventHandlerAutoSuggestBox_AutoSuggestBoxQuerySubmittedEventArgs: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgs }
+
+    internal func InvokeImpl(_ sender: WinUI.AutoSuggestBox?, _ args: WinUI.AutoSuggestBoxQuerySubmittedEventArgs?) throws {
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgs.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgsBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.AutoSuggestBox?, WinUI.AutoSuggestBoxQuerySubmittedEventArgs?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxQuerySubmittedEventArgs
+    internal typealias SwiftABI = WinUI.TypedEventHandlerAutoSuggestBox_AutoSuggestBoxQuerySubmittedEventArgs
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x5935f64e, Data2: 0x3ecf, Data3: 0x542c, Data4: ( 0x82,0x67,0xc8,0xe3,0x01,0x0a,0xd6,0x1b ))// 5935f64e-3ecf-542c-8267-c8e3010ad61b
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgs {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.AutoSuggestBox? = .from(abi: ComPtr($1))
+        let args: WinUI.AutoSuggestBoxSuggestionChosenEventArgs? = .from(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsBridge>
+internal class TypedEventHandlerAutoSuggestBox_AutoSuggestBoxSuggestionChosenEventArgs: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgs }
+
+    internal func InvokeImpl(_ sender: WinUI.AutoSuggestBox?, _ args: WinUI.AutoSuggestBoxSuggestionChosenEventArgs?) throws {
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgs.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgsBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.AutoSuggestBox?, WinUI.AutoSuggestBoxSuggestionChosenEventArgs?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxSuggestionChosenEventArgs
+    internal typealias SwiftABI = WinUI.TypedEventHandlerAutoSuggestBox_AutoSuggestBoxSuggestionChosenEventArgs
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x26a9ca98, Data2: 0x6077, Data3: 0x5255, Data4: ( 0x91,0x2b,0x47,0x63,0x24,0xe3,0xb3,0x1c ))// 26a9ca98-6077-5255-912b-476324e3b31c
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgs {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.AutoSuggestBox? = .from(abi: ComPtr($1))
+        let args: WinUI.AutoSuggestBoxTextChangedEventArgs? = .from(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsBridge>
+internal class TypedEventHandlerAutoSuggestBox_AutoSuggestBoxTextChangedEventArgs: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgs }
+
+    internal func InvokeImpl(_ sender: WinUI.AutoSuggestBox?, _ args: WinUI.AutoSuggestBoxTextChangedEventArgs?) throws {
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgs.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgsBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.AutoSuggestBox?, WinUI.AutoSuggestBoxTextChangedEventArgs?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBox___x_ABI_CMicrosoft__CUI__CXaml__CControls__CAutoSuggestBoxTextChangedEventArgs
+    internal typealias SwiftABI = WinUI.TypedEventHandlerAutoSuggestBox_AutoSuggestBoxTextChangedEventArgs
 
     internal static func from(abi: ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
@@ -33563,6 +33710,400 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__
     internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.MediaTransportControls?, WinUI.MediaTransportControlsThumbnailRequestedEventArgs?>
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CMediaTransportControls___x_ABI_CMicrosoft__CUI__CXaml__CMedia__CMediaTransportControlsThumbnailRequestedEventArgs
     internal typealias SwiftABI = WinUI.TypedEventHandlerMediaTransportControls_MediaTransportControlsThumbnailRequestedEventArgs
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectable: WindowsFoundation.IID {
+    .init(Data1: 0x86e94ce6, Data2: 0x31da, Data3: 0x595b, Data4: ( 0x80,0xc2,0x03,0xfb,0x66,0xcc,0xb5,0xd3 ))// 86e94ce6-31da-595b-80c2-03fb66ccb5d3
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectable {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.NavigationView? = .from(abi: ComPtr($1))
+        let args: Any? = __ABI_.AnyWrapper.unwrapFrom(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableBridge>
+internal class TypedEventHandlerNavigationView_Any: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectable }
+
+    internal func InvokeImpl(_ sender: WinUI.NavigationView?, _ args: Any?) throws {
+        let argsWrapper = __ABI_.AnyWrapper(args)
+        let _args = try! argsWrapper?.toABI { $0 }
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectable.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), _args))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectableBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.NavigationView?, Any?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView_IInspectable
+    internal typealias SwiftABI = WinUI.TypedEventHandlerNavigationView_Any
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0xec259ad4, Data2: 0x686d, Data3: 0x5749, Data4: ( 0xbb,0x49,0x40,0xd4,0xde,0x4b,0x3e,0xe5 ))// ec259ad4-686d-5749-bb49-40d4de4b3ee5
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgs {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.NavigationView? = .from(abi: ComPtr($1))
+        let args: WinUI.NavigationViewBackRequestedEventArgs? = .from(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsBridge>
+internal class TypedEventHandlerNavigationView_NavigationViewBackRequestedEventArgs: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgs }
+
+    internal func InvokeImpl(_ sender: WinUI.NavigationView?, _ args: WinUI.NavigationViewBackRequestedEventArgs?) throws {
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgs.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgsBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewBackRequestedEventArgs?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewBackRequestedEventArgs
+    internal typealias SwiftABI = WinUI.TypedEventHandlerNavigationView_NavigationViewBackRequestedEventArgs
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x7f6a2693, Data2: 0xdefa, Data3: 0x51fe, Data4: ( 0xac,0x1c,0xa5,0x4d,0xba,0xbb,0xd6,0x9a ))// 7f6a2693-defa-51fe-ac1c-a54dbabbd69a
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgs {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.NavigationView? = .from(abi: ComPtr($1))
+        let args: WinUI.NavigationViewDisplayModeChangedEventArgs? = .from(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsBridge>
+internal class TypedEventHandlerNavigationView_NavigationViewDisplayModeChangedEventArgs: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgs }
+
+    internal func InvokeImpl(_ sender: WinUI.NavigationView?, _ args: WinUI.NavigationViewDisplayModeChangedEventArgs?) throws {
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgs.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgsBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewDisplayModeChangedEventArgs?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewDisplayModeChangedEventArgs
+    internal typealias SwiftABI = WinUI.TypedEventHandlerNavigationView_NavigationViewDisplayModeChangedEventArgs
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x01ef7a67, Data2: 0x9f90, Data3: 0x53fd, Data4: ( 0xbb,0x59,0x52,0x02,0x80,0x15,0x5e,0x06 ))// 01ef7a67-9f90-53fd-bb59-520280155e06
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgs {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.NavigationView? = .from(abi: ComPtr($1))
+        let args: WinUI.NavigationViewItemCollapsedEventArgs? = .from(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsBridge>
+internal class TypedEventHandlerNavigationView_NavigationViewItemCollapsedEventArgs: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgs }
+
+    internal func InvokeImpl(_ sender: WinUI.NavigationView?, _ args: WinUI.NavigationViewItemCollapsedEventArgs?) throws {
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgs.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgsBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewItemCollapsedEventArgs?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemCollapsedEventArgs
+    internal typealias SwiftABI = WinUI.TypedEventHandlerNavigationView_NavigationViewItemCollapsedEventArgs
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0xcc7e73d0, Data2: 0x23f9, Data3: 0x50a5, Data4: ( 0x89,0xa5,0x5d,0xbd,0x32,0x1b,0x91,0x20 ))// cc7e73d0-23f9-50a5-89a5-5dbd321b9120
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgs {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.NavigationView? = .from(abi: ComPtr($1))
+        let args: WinUI.NavigationViewItemExpandingEventArgs? = .from(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsBridge>
+internal class TypedEventHandlerNavigationView_NavigationViewItemExpandingEventArgs: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgs }
+
+    internal func InvokeImpl(_ sender: WinUI.NavigationView?, _ args: WinUI.NavigationViewItemExpandingEventArgs?) throws {
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgs.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgsBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewItemExpandingEventArgs?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemExpandingEventArgs
+    internal typealias SwiftABI = WinUI.TypedEventHandlerNavigationView_NavigationViewItemExpandingEventArgs
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0x8e7678c6, Data2: 0x4683, Data3: 0x59d9, Data4: ( 0xac,0xd2,0xb4,0x6e,0x7c,0x63,0xf1,0x6a ))// 8e7678c6-4683-59d9-acd2-b46e7c63f16a
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgs {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.NavigationView? = .from(abi: ComPtr($1))
+        let args: WinUI.NavigationViewItemInvokedEventArgs? = .from(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsBridge>
+internal class TypedEventHandlerNavigationView_NavigationViewItemInvokedEventArgs: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgs }
+
+    internal func InvokeImpl(_ sender: WinUI.NavigationView?, _ args: WinUI.NavigationViewItemInvokedEventArgs?) throws {
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgs.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgsBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewItemInvokedEventArgs?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewItemInvokedEventArgs
+    internal typealias SwiftABI = WinUI.TypedEventHandlerNavigationView_NavigationViewItemInvokedEventArgs
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0xd884e2d1, Data2: 0x6f35, Data3: 0x5fe8, Data4: ( 0xae,0x08,0xe3,0x34,0x21,0x73,0x43,0xad ))// d884e2d1-6f35-5fe8-ae08-e334217343ad
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgs {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.NavigationView? = .from(abi: ComPtr($1))
+        let args: WinUI.NavigationViewPaneClosingEventArgs? = .from(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsBridge>
+internal class TypedEventHandlerNavigationView_NavigationViewPaneClosingEventArgs: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgs }
+
+    internal func InvokeImpl(_ sender: WinUI.NavigationView?, _ args: WinUI.NavigationViewPaneClosingEventArgs?) throws {
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgs.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgsBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewPaneClosingEventArgs?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewPaneClosingEventArgs
+    internal typealias SwiftABI = WinUI.TypedEventHandlerNavigationView_NavigationViewPaneClosingEventArgs
+
+    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+        guard let abi = abi else { return nil }
+        let _default = SwiftABI(abi)
+        let handler: Handler = { (sender, args) in
+            try! _default.InvokeImpl(sender, args)
+        }
+        return handler
+    }
+}
+private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgs: WindowsFoundation.IID {
+    .init(Data1: 0xd97a5008, Data2: 0xe3cc, Data3: 0x5ef4, Data4: ( 0xac,0x51,0x96,0xc6,0x38,0xd9,0x61,0xef ))// d97a5008-e3cc-5ef4-ac51-96c638d961ef
+}
+
+internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgs {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsVtbl = .init(
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsWrapper.addRef($0) },
+    Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsWrapper.release($0) },
+    Invoke: {
+        guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let sender: WinUI.NavigationView? = .from(abi: ComPtr($1))
+        let args: WinUI.NavigationViewSelectionChangedEventArgs? = .from(abi: ComPtr($2))
+        __unwrapped__instance(sender, args)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsWrapper = InterfaceWrapperBase<WinUI.__x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsBridge>
+internal class TypedEventHandlerNavigationView_NavigationViewSelectionChangedEventArgs: WindowsFoundation.IUnknown {
+    override public class var IID: WindowsFoundation.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgs }
+
+    internal func InvokeImpl(_ sender: WinUI.NavigationView?, _ args: WinUI.NavigationViewSelectionChangedEventArgs?) throws {
+        _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgs.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
+        }
+    }
+
+}
+
+internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgsBridge : WinRTDelegateBridge {
+    internal typealias Handler = WindowsFoundation.TypedEventHandler<WinUI.NavigationView?, WinUI.NavigationViewSelectionChangedEventArgs?>
+    internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationView___x_ABI_CMicrosoft__CUI__CXaml__CControls__CNavigationViewSelectionChangedEventArgs
+    internal typealias SwiftABI = WinUI.TypedEventHandlerNavigationView_NavigationViewSelectionChangedEventArgs
 
     internal static func from(abi: ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
@@ -37333,3 +37874,4 @@ public extension EventSource where Handler == TypedEventHandler<IScrollControlle
         }
     }
 }
+

--- a/Sources/WinUI/Generated/WinUI+MakeFromAbi.swift
+++ b/Sources/WinUI/Generated/WinUI+MakeFromAbi.swift
@@ -368,6 +368,22 @@ fileprivate func makeAppBarFrom(abi: WindowsFoundation.IInspectable) -> Any {
     return AppBar(fromAbi: abi)
 }
 
+fileprivate func makeAutoSuggestBoxFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return AutoSuggestBox(fromAbi: abi)
+}
+
+fileprivate func makeAutoSuggestBoxQuerySubmittedEventArgsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return AutoSuggestBoxQuerySubmittedEventArgs(fromAbi: abi)
+}
+
+fileprivate func makeAutoSuggestBoxSuggestionChosenEventArgsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return AutoSuggestBoxSuggestionChosenEventArgs(fromAbi: abi)
+}
+
+fileprivate func makeAutoSuggestBoxTextChangedEventArgsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return AutoSuggestBoxTextChangedEventArgs(fromAbi: abi)
+}
+
 fileprivate func makeBitmapIconFrom(abi: WindowsFoundation.IInspectable) -> Any {
     return BitmapIcon(fromAbi: abi)
 }
@@ -556,6 +572,14 @@ fileprivate func makeImageIconFrom(abi: WindowsFoundation.IInspectable) -> Any {
     return ImageIcon(fromAbi: abi)
 }
 
+fileprivate func makeInfoBadgeFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return InfoBadge(fromAbi: abi)
+}
+
+fileprivate func makeInfoBadgeTemplateSettingsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return InfoBadgeTemplateSettings(fromAbi: abi)
+}
+
 fileprivate func makeInfoBarFrom(abi: WindowsFoundation.IInspectable) -> Any {
     return InfoBar(fromAbi: abi)
 }
@@ -698,6 +722,50 @@ fileprivate func makeMenuFlyoutSeparatorFrom(abi: WindowsFoundation.IInspectable
 
 fileprivate func makeMenuFlyoutSubItemFrom(abi: WindowsFoundation.IInspectable) -> Any {
     return MenuFlyoutSubItem(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationView(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewBackRequestedEventArgsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationViewBackRequestedEventArgs(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewDisplayModeChangedEventArgsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationViewDisplayModeChangedEventArgs(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewItemFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationViewItem(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewItemBaseFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationViewItemBase(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewItemCollapsedEventArgsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationViewItemCollapsedEventArgs(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewItemExpandingEventArgsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationViewItemExpandingEventArgs(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewItemInvokedEventArgsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationViewItemInvokedEventArgs(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewPaneClosingEventArgsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationViewPaneClosingEventArgs(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewSelectionChangedEventArgsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationViewSelectionChangedEventArgs(fromAbi: abi)
+}
+
+fileprivate func makeNavigationViewTemplateSettingsFrom(abi: WindowsFoundation.IInspectable) -> Any {
+    return NavigationViewTemplateSettings(fromAbi: abi)
 }
 
 fileprivate func makePageFrom(abi: WindowsFoundation.IInspectable) -> Any {
@@ -2029,6 +2097,10 @@ public class __MakeFromAbi: MakeFromAbi {
             case "IRawElementProviderSimple": return makeIRawElementProviderSimpleFrom(abi: abi)
             case "AnchorRequestedEventArgs": return makeAnchorRequestedEventArgsFrom(abi: abi)
             case "AppBar": return makeAppBarFrom(abi: abi)
+            case "AutoSuggestBox": return makeAutoSuggestBoxFrom(abi: abi)
+            case "AutoSuggestBoxQuerySubmittedEventArgs": return makeAutoSuggestBoxQuerySubmittedEventArgsFrom(abi: abi)
+            case "AutoSuggestBoxSuggestionChosenEventArgs": return makeAutoSuggestBoxSuggestionChosenEventArgsFrom(abi: abi)
+            case "AutoSuggestBoxTextChangedEventArgs": return makeAutoSuggestBoxTextChangedEventArgsFrom(abi: abi)
             case "BitmapIcon": return makeBitmapIconFrom(abi: abi)
             case "Border": return makeBorderFrom(abi: abi)
             case "Button": return makeButtonFrom(abi: abi)
@@ -2076,6 +2148,8 @@ public class __MakeFromAbi: MakeFromAbi {
             case "IconSourceElement": return makeIconSourceElementFrom(abi: abi)
             case "Image": return makeImageFrom(abi: abi)
             case "ImageIcon": return makeImageIconFrom(abi: abi)
+            case "InfoBadge": return makeInfoBadgeFrom(abi: abi)
+            case "InfoBadgeTemplateSettings": return makeInfoBadgeTemplateSettingsFrom(abi: abi)
             case "InfoBar": return makeInfoBarFrom(abi: abi)
             case "InfoBarClosedEventArgs": return makeInfoBarClosedEventArgsFrom(abi: abi)
             case "InfoBarClosingEventArgs": return makeInfoBarClosingEventArgsFrom(abi: abi)
@@ -2112,6 +2186,17 @@ public class __MakeFromAbi: MakeFromAbi {
             case "MenuFlyoutItemBase": return makeMenuFlyoutItemBaseFrom(abi: abi)
             case "MenuFlyoutSeparator": return makeMenuFlyoutSeparatorFrom(abi: abi)
             case "MenuFlyoutSubItem": return makeMenuFlyoutSubItemFrom(abi: abi)
+            case "NavigationView": return makeNavigationViewFrom(abi: abi)
+            case "NavigationViewBackRequestedEventArgs": return makeNavigationViewBackRequestedEventArgsFrom(abi: abi)
+            case "NavigationViewDisplayModeChangedEventArgs": return makeNavigationViewDisplayModeChangedEventArgsFrom(abi: abi)
+            case "NavigationViewItem": return makeNavigationViewItemFrom(abi: abi)
+            case "NavigationViewItemBase": return makeNavigationViewItemBaseFrom(abi: abi)
+            case "NavigationViewItemCollapsedEventArgs": return makeNavigationViewItemCollapsedEventArgsFrom(abi: abi)
+            case "NavigationViewItemExpandingEventArgs": return makeNavigationViewItemExpandingEventArgsFrom(abi: abi)
+            case "NavigationViewItemInvokedEventArgs": return makeNavigationViewItemInvokedEventArgsFrom(abi: abi)
+            case "NavigationViewPaneClosingEventArgs": return makeNavigationViewPaneClosingEventArgsFrom(abi: abi)
+            case "NavigationViewSelectionChangedEventArgs": return makeNavigationViewSelectionChangedEventArgsFrom(abi: abi)
+            case "NavigationViewTemplateSettings": return makeNavigationViewTemplateSettingsFrom(abi: abi)
             case "Page": return makePageFrom(abi: abi)
             case "Panel": return makePanelFrom(abi: abi)
             case "PasswordBox": return makePasswordBoxFrom(abi: abi)

--- a/generate-bindings.ps1
+++ b/generate-bindings.ps1
@@ -137,5 +137,5 @@ function Invoke-SwiftWinRT() {
 
 $PackagesDir = Join-Path $PSScriptRoot ".packages"
 Restore-Nuget -PackagesDir $PackagesDir
-#Invoke-SwiftWinRT -PackagesDir $PackagesDir
+Invoke-SwiftWinRT -PackagesDir $PackagesDir
 Write-Host "SwiftWinRT bindings generated successfully!" -ForegroundColor Green

--- a/projections.json
+++ b/projections.json
@@ -106,6 +106,7 @@
     "Microsoft.UI.Xaml.Shapes.Rectangle",
     "Microsoft.UI.Xaml.Window",
     "Microsoft.UI.Xaml.XamlTypeInfo.XamlControlsXamlMetaDataProvider",
+    "Microsoft.UI.Xaml.Controls.NavigationView"
   ],
   "exclude": [
   ]


### PR DESCRIPTION
This is to enable `NavigationView` and `NavigationViewItem`. I tested it in both `debug` and `release` profiles and found no build issues.