### PR TITLE
Add outdated warning prior to archiving repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # swift-winui
+
+> [!WARNING]
+> This project contains an outdated snapshot of a subset of WinRT projections generated with [swift-winrt](https://github.com/thebrowsercompany/swift-winrt), provided for illustration purposes. To use WinRT APIs in your Swift project, we recommend using [swift-winrt](https://github.com/thebrowsercompany/swift-winrt) directly to generate your own projections.
+
 Swift Language Bindings for WinUI
 
 ## APIs


### PR DESCRIPTION
I will archive this repository after merging this change. Folks have been reporting issues with our pregenerated projections repos and we're neither keeping them updated nor providing ongoing support, so better avoid confusion by archiving the repos.